### PR TITLE
Fixes issue #165, Crash when entering disqualify UI

### DIFF
--- a/RaceHorology/DisqualifyUC.xaml.cs
+++ b/RaceHorology/DisqualifyUC.xaml.cs
@@ -153,6 +153,9 @@ namespace RaceHorology
 
     private void setRaceRun(RaceRun rr)
     {
+      if (rr == null)
+        return;
+
       _currentRaceRun = rr;
       connectUiToRaceRun(_currentRaceRun);
 


### PR DESCRIPTION
The dialog is designed to have the member _currentRaceRun to be non-null.
However, this could happen for a short time while clearing and refilling the race run combo box.
fixes #165
