### PR TITLE
Fix crash while getting name as string from System.Windows.Data.CollectionViewGroup

### DIFF
--- a/RaceHorologyLib/JsonConversion.cs
+++ b/RaceHorologyLib/JsonConversion.cs
@@ -311,7 +311,7 @@ namespace RaceHorologyLib
           System.Windows.Data.CollectionViewGroup cvGroup = group as System.Windows.Data.CollectionViewGroup;
 
           List<object> dstItems = new List<object>();
-          groupedData.Add(cvGroup.Name, dstItems);
+          groupedData.Add(cvGroup.GetName(), dstItems);
 
           foreach (var item in cvGroup.Items)
             dstItems.Add(item);

--- a/RaceHorologyLib/PDFReports.cs
+++ b/RaceHorologyLib/PDFReports.cs
@@ -1181,7 +1181,7 @@ namespace RaceHorologyLib
         foreach (var group in results.Groups)
         {
           System.Windows.Data.CollectionViewGroup cvGroup = group as System.Windows.Data.CollectionViewGroup;
-          addLineToTable(table, cvGroup.Name.ToString());
+          addLineToTable(table, cvGroup.GetName());
 
           int i = 0;
           foreach (var result in cvGroup.Items)

--- a/RaceHorologyLib/ResultCharts.cs
+++ b/RaceHorologyLib/ResultCharts.cs
@@ -137,7 +137,7 @@ namespace RaceHorologyLib
         {
           if (group is System.Windows.Data.CollectionViewGroup cvGroup)
           {
-            var lblGroup = axis.CustomLabels.Add(x1 - 0.5, x1 + 0.5, workaroundGermanUmlaut(cvGroup.Name.ToString()));
+            var lblGroup = axis.CustomLabels.Add(x1 - 0.5, x1 + 0.5, workaroundGermanUmlaut(cvGroup.GetName()));
             lblGroup.GridTicks = GridTickTypes.None;
 
             // Second Level if possible
@@ -328,7 +328,7 @@ namespace RaceHorologyLib
         {
           if (group is System.Windows.Data.CollectionViewGroup cvGroup)
           {
-            System.Windows.Forms.DataVisualization.Charting.Series ds = new Series(cvGroup.Name.ToString());
+            System.Windows.Forms.DataVisualization.Charting.Series ds = new Series(cvGroup.GetName());
 
             if (cvGroup.Items.Count > 0)
             {
@@ -341,7 +341,7 @@ namespace RaceHorologyLib
             chart.Series.Add(ds);
             ds.Enabled = true;
 
-            //Series dsBB = new Series("BoxPlot" + cvGroup.Name.ToString());
+            //Series dsBB = new Series("BoxPlot" + cvGroup.GetName());
             //dsBB.ChartType = SeriesChartType.BoxPlot;
             //dsBB["BoxPlotSeries"] = ds.Name;
             //dsBB["BoxPlotWhiskerPercentile"] = "5";

--- a/RaceHorologyLib/Utilities.cs
+++ b/RaceHorologyLib/Utilities.cs
@@ -622,6 +622,18 @@ namespace RaceHorologyLib
   }
 
 
+  public static class CollectionViewGroupUtils
+  {
+    public static string GetName(this System.Windows.Data.CollectionViewGroup cvGroup)
+    {
+      string groupName = string.Empty;
+      if (cvGroup?.Name != null)
+        groupName = cvGroup.Name.ToString();
+
+      return groupName;
+    }
+
+  }
 
 
 

--- a/RaceHorologyLibTest/TestUtilities.cs
+++ b/RaceHorologyLibTest/TestUtilities.cs
@@ -189,7 +189,7 @@ namespace RaceHorologyLibTest
         foreach (var group in view.Groups)
         {
           System.Windows.Data.CollectionViewGroup cvGroup = group as System.Windows.Data.CollectionViewGroup;
-          // Group(Name) would be: cvGroup.Name.ToString()
+          // Group(Name) would be: cvGroup.GetName()
 
           foreach (var item in cvGroup.Items)
             resList.Add((T)item);


### PR DESCRIPTION
Introduced extension method GetName() which can be used safely in case CollectionViewGroup.Name is null
