### PR TITLE
Support of FIS Live Timing - Error Handling

### DIFF
--- a/LiveTimingFIS/LiveTimingFIS.cs
+++ b/LiveTimingFIS/LiveTimingFIS.cs
@@ -401,6 +401,7 @@ namespace LiveTimingFIS
       _fisPassword = fisPassword;
 
       scheduleTransfer(new LTTransfer(getXmlClearRace(), _tcpClient));
+      scheduleTransfer(new LTTransfer(getXmlStatusUpdateInfo(""), _tcpClient));
       scheduleTransfer(new LTTransfer(getXmlRaceInfo(_race), _tcpClient));
       _isLoggedOn = true;
     }

--- a/LiveTimingFIS/LiveTimingFIS.cs
+++ b/LiveTimingFIS/LiveTimingFIS.cs
@@ -123,6 +123,9 @@ namespace LiveTimingFIS
             n.Dispose();
         }
 
+        foreach(var rr in _race.GetRuns())
+          rr.OnTrackChanged -= raceRun_OnTrackChanged;
+
         disposedValue = true;
       }
     }
@@ -185,7 +188,6 @@ namespace LiveTimingFIS
         }
       };
       _notifier.Add(resultsNotifier);
-      //raceRun.InFinishChanged += raceRun_InFinishChanged;
 
       raceRun.OnTrackChanged += raceRun_OnTrackChanged;
     }

--- a/RaceHorologyLib/LiveTiming.cs
+++ b/RaceHorologyLib/LiveTiming.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace RaceHorologyLib
 {
+
+  public delegate void OnStatusChanged();
+
   public interface ILiveTiming
   {
 
@@ -13,6 +16,10 @@ namespace RaceHorologyLib
 
     void Start();
     void Stop();
+
+    bool Started { get; }
+
+    event OnStatusChanged StatusChanged;
 
   }
 }


### PR DESCRIPTION
FIS Livetiming will stop in case of errors, e.g. closed sockets caused by wrong password