### PR TITLE
Zuordnung zwischen Zeitstempel und Startnummer können am PC korrigiert werden

### DIFF
--- a/RaceHorology/MainWindow.xaml
+++ b/RaceHorology/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="RaceHorology.MainWindow"
+<Window x:Class="RaceHorology.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -99,12 +99,16 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
           </Grid.ColumnDefinitions>
           <Label x:Name="lblTimingDeviceLBL" Content="Live Zeitnahme: " Margin="0" VerticalAlignment="Top" FontSize="12" Grid.Column="0"/>
           <Label x:Name="lblTimingDevice" Content="---" HorizontalAlignment="Left" Margin="0" VerticalAlignment="Top" FontSize="12"  Grid.Column="1"/>
-          <Button x:Name="btnTimingDeviceDebug" Content="Protokoll" Margin="10,0,10,0" Padding="5,2,5,2"  Grid.Column="2" Click="btnTimingDeviceDebug_Click"/>
+          
+          <Button x:Name="btnTimingDeviceStartStop" Content="..." Margin="10,0,10,0" Padding="5,2,5,2"  Grid.Column="2" Click="btnTimingDeviceStartStop_Click"/>
+
+          <Button x:Name="btnTimingDeviceDebug" Content="Protokoll" Margin="10,0,10,0" Padding="5,2,5,2"  Grid.Column="3" Click="btnTimingDeviceDebug_Click"/>
         </Grid>
-      </StatusBarItem>      
+      </StatusBarItem>
 
     </StatusBar>
 

--- a/RaceHorology/MainWindow.xaml
+++ b/RaceHorology/MainWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="RaceHorology.MainWindow"
+﻿<Window x:Class="RaceHorology.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -8,7 +8,7 @@
         xmlns:Settings="clr-namespace:RaceHorology.Settings" 
         Settings:WindowSettings.Save="True"
         mc:Ignorable="d"
-        Title="Race Horology" WindowState="Maximized">
+        Title="Race Horology" WindowState="Maximized" d:DesignHeight="800" d:DesignWidth="1024">
 
   <Window.CommandBindings>
     <CommandBinding Command="New"  Executed="NewCommandBinding_Executed" />

--- a/RaceHorology/MainWindow.xaml.cs
+++ b/RaceHorology/MainWindow.xaml.cs
@@ -504,11 +504,12 @@ namespace RaceHorology
 
         // Create new devices
         _timingDevicePartcipantAssigner = new LiveTimeParticipantAssigning(newTimingDevice);
-        _liveTimingMeasurement.AddTimingDevice(_timingDevice, true);
+        _liveTimingMeasurement.AddTimingDevice(newTimingDevice, true);
         _liveTimingMeasurement.AddTimingDevice(_timingDevicePartcipantAssigner, false);
-        if (_timingDevice is ILiveDateTimeProvider)
-          _liveTimingMeasurement.SetLiveDateTimeProvider(_timingDevice as ILiveDateTimeProvider);
+        if (newTimingDevice is ILiveDateTimeProvider)
+          _liveTimingMeasurement.SetLiveDateTimeProvider(newTimingDevice as ILiveDateTimeProvider);
 
+        _timingDevice = newTimingDevice;
         _timingDevice.Start();
       }
     }

--- a/RaceHorology/MainWindow.xaml.cs
+++ b/RaceHorology/MainWindow.xaml.cs
@@ -537,6 +537,7 @@ namespace RaceHorology
       {
         var tdpa = _timingDevicePartcipantAssigner[0];
         _timingDevicePartcipantAssigner.Remove(tdpa);
+        _liveTimingMeasurement.RemoveTimingDevice(tdpa);
         tdpa.Dispose();
       }
     }

--- a/RaceHorology/MainWindow.xaml.cs
+++ b/RaceHorology/MainWindow.xaml.cs
@@ -509,7 +509,7 @@ namespace RaceHorology
         _timingDevice = null;
       }
       // Cleanup old devices
-      while (_timingDevicePartcipantAssigner.Count > 0)
+      while (_timingDevicePartcipantAssigner != null && _timingDevicePartcipantAssigner.Count > 0)
       {
         var tdpa = _timingDevicePartcipantAssigner[0];
         _timingDevicePartcipantAssigner.Remove(tdpa);

--- a/RaceHorology/MainWindow.xaml.cs
+++ b/RaceHorology/MainWindow.xaml.cs
@@ -118,6 +118,8 @@ namespace RaceHorology
       mnuMain.DataContext = _menuVM;
 
       StartDSVAlpinServer();
+
+      UpdateLiveTimingDeviceStatus(null, null);
     }
 
     protected override void OnClosed(EventArgs e)
@@ -546,37 +548,41 @@ namespace RaceHorology
     }
 
 
-    private void LiveTimingStart_Click(object sender, RoutedEventArgs e)
+    private void btnTimingDeviceStartStop_Click(object sender, RoutedEventArgs e)
     {
       if (_liveTimingMeasurement == null)
         return;
 
-      _liveTimingMeasurement.AutoAddParticipants = Properties.Settings.Default.AutoAddParticipants;
-      _liveTimingMeasurement.Start();
+      var timingDevice = _liveTimingMeasurement.LiveTimingDevice;
+      if (timingDevice == null)
+        return;
+
+      if (timingDevice.IsOnline)
+        timingDevice.Stop();
+      else
+        timingDevice.Start();
     }
 
-    private void LiveTimingStop_Click(object sender, RoutedEventArgs e)
-    {
-      if (_liveTimingMeasurement == null)
-        return;
-     
-      _liveTimingMeasurement.Stop();
-    }
 
     private void UpdateLiveTimingDeviceStatus(object sender, System.Timers.ElapsedEventArgs e)
     {
-      var timingDevice = _liveTimingMeasurement.LiveTimingDevice;
-      var dateTimeProvider = _liveTimingMeasurement.LiveDateTimeProvider;
+      bool timingDeviceOnline = false;
+      var timingDevice = _liveTimingMeasurement != null ? _liveTimingMeasurement.LiveTimingDevice : null;
+      var dateTimeProvider = _liveTimingMeasurement != null ? _liveTimingMeasurement.LiveDateTimeProvider : null;
 
-      string str = "kein Zeitmessgerät ausgewählt";
+      string str = "---";
       if (timingDevice!=null && dateTimeProvider!=null)
       { 
         str = timingDevice.GetDeviceInfo() + ", " + timingDevice.GetStatusInfo() + ", " + dateTimeProvider.GetCurrentDayTime().ToString(@"hh\:mm\:ss");
+        timingDeviceOnline = timingDevice.IsOnline;
       }
 
       Application.Current.Dispatcher.Invoke(() =>
       {
         lblTimingDevice.Content = str;
+        btnTimingDeviceStartStop.Content = timingDeviceOnline ? "Trennen" : "Verbinden";
+        btnTimingDeviceStartStop.IsEnabled = timingDevice != null;
+        btnTimingDeviceDebug.IsEnabled = timingDevice != null;
       });
     }
 

--- a/RaceHorology/MainWindow.xaml.cs
+++ b/RaceHorology/MainWindow.xaml.cs
@@ -518,11 +518,10 @@ namespace RaceHorology
     {
       if (_timingDevice != null)
       {
-        _timingDevice.Stop();
-
         _liveTimingMeasurement.RemoveTimingDevice(_timingDevice);
         _liveTimingMeasurement.SetLiveDateTimeProvider(null);
 
+        _timingDevice.Stop();
         _timingDevice = null;
       }
       if (_timingDevicePartcipantAssigner != null)

--- a/RaceHorology/MeasurementLogAndParticipantAssignment.xaml
+++ b/RaceHorology/MeasurementLogAndParticipantAssignment.xaml
@@ -1,0 +1,30 @@
+﻿<UserControl x:Class="RaceHorology.MeasurementLogAndParticipantAssignment"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:RaceHorology"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid Width="Auto" Grid.Row="6">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*"/>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="1*"/>
+      </Grid.ColumnDefinitions>
+      <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="0"  Grid.Column="0" Grid.ColumnSpan="1" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+        <DataGrid.Columns>
+        <DataGridTextColumn local:DataGridUtil.Name="Time" Header="Zeit" Binding="{Binding Time, Mode=OneWay, StringFormat=\{0:hh\\:mm\\:ss\\\,ffff\}}"/>
+        <DataGridTextColumn local:DataGridUtil.Name="Valid" Header="Gültig" Binding="{Binding Valid, Mode=OneWay}"/>
+        <DataGridTextColumn local:DataGridUtil.Name="StartNumber" Header="StNr" Binding="{Binding StartNumber, Mode=OneWay}"/>
+      </DataGrid.Columns>
+        <DataGrid.Style>
+          <Style TargetType="DataGrid">
+            <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
+          </Style>
+        </DataGrid.Style>
+      </DataGrid>
+    </Grid>
+</UserControl>

--- a/RaceHorology/MeasurementLogAndParticipantAssignment.xaml
+++ b/RaceHorology/MeasurementLogAndParticipantAssignment.xaml
@@ -15,7 +15,7 @@
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="1*"/>
     </Grid.ColumnDefinitions>
-    <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="0"  Grid.Column="0" Grid.ColumnSpan="1" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False" SelectionMode="Single" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+    <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="0"  Grid.Column="0" Grid.ColumnSpan="1" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False" SelectionMode="Single" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True" SelectionChanged="dgParticipantAssigning_SelectionChanged">
       <DataGrid.Columns>
         <DataGridTextColumn local:DataGridUtil.Name="Time" Header="Zeit" Binding="{Binding Time, Mode=OneWay, StringFormat=\{0:hh\\:mm\\:ss\\\,ffff\}}"/>
         <DataGridTextColumn local:DataGridUtil.Name="Valid" Header="Gültig" Binding="{Binding Valid, Mode=OneWay}"/>
@@ -46,7 +46,7 @@
       </Grid.ColumnDefinitions>
 
       <Label Content="Korrektur - StNr:" Grid.Row="0" Grid.Column="0"/>
-      <TextBox x:Name="txtStartNumber" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="1" Margin="5,0,5,0" Width="80" VerticalAlignment="Center" HorizontalAlignment="Left" TextAlignment="Right" TextChanged="TxtStartNumber_TextChanged" GotFocus="Txt_GotFocus_SelectAll"/>
+      <TextBox x:Name="txtStartNumber" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="1" Margin="5,0,5,0" Width="40" VerticalAlignment="Center" HorizontalAlignment="Left" TextAlignment="Right" TextChanged="TxtStartNumber_TextChanged" GotFocus="Txt_GotFocus_SelectAll"/>
       <TextBox x:Name="txtParticipant" Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="1" Margin="5,0,5,0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" VerticalAlignment="Center" IsEnabled="False"/>
       <Button x:Name="btnStore" Grid.Row="0" Grid.Column="3" Content="Zuweisen" Margin="5,0,5,0"  VerticalAlignment="Center" Click="BtnStore_Click"/>
     </Grid>

--- a/RaceHorology/MeasurementLogAndParticipantAssignment.xaml
+++ b/RaceHorology/MeasurementLogAndParticipantAssignment.xaml
@@ -6,25 +6,49 @@
              xmlns:local="clr-namespace:RaceHorology"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    <Grid Width="Auto" Grid.Row="6">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="*"/>
-        <RowDefinition Height="Auto"/>
-      </Grid.RowDefinitions>
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="1*"/>
-      </Grid.ColumnDefinitions>
-      <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="0"  Grid.Column="0" Grid.ColumnSpan="1" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
-        <DataGrid.Columns>
+  <Grid Width="Auto" Grid.Row="6">
+    <Grid.RowDefinitions>
+      <RowDefinition/>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="1*"/>
+    </Grid.ColumnDefinitions>
+    <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="0"  Grid.Column="0" Grid.ColumnSpan="1" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False" SelectionMode="Single" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+      <DataGrid.Columns>
         <DataGridTextColumn local:DataGridUtil.Name="Time" Header="Zeit" Binding="{Binding Time, Mode=OneWay, StringFormat=\{0:hh\\:mm\\:ss\\\,ffff\}}"/>
         <DataGridTextColumn local:DataGridUtil.Name="Valid" Header="Gültig" Binding="{Binding Valid, Mode=OneWay}"/>
         <DataGridTextColumn local:DataGridUtil.Name="StartNumber" Header="StNr" Binding="{Binding StartNumber, Mode=OneWay}"/>
       </DataGrid.Columns>
-        <DataGrid.Style>
-          <Style TargetType="DataGrid">
-            <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
-          </Style>
-        </DataGrid.Style>
-      </DataGrid>
+      <DataGrid.Style>
+        <Style TargetType="DataGrid">
+          <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
+        </Style>
+      </DataGrid.Style>
+      <DataGrid.CellStyle>
+        <Style TargetType="{x:Type DataGridCell}">
+          <Style.Triggers>
+            <DataTrigger Binding="{Binding Valid}" Value="False" >
+              <Setter Property="Foreground" Value="#202020" />
+              <Setter Property="FontStyle" Value="Italic" />
+            </DataTrigger>
+          </Style.Triggers>
+        </Style>
+      </DataGrid.CellStyle>
+    </DataGrid>
+    <Grid Grid.Row="1">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="Auto"/>
+      </Grid.ColumnDefinitions>
+
+      <Label Content="Korrektur - StNr:" Grid.Row="0" Grid.Column="0"/>
+      <TextBox x:Name="txtStartNumber" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="1" Margin="5,0,5,0" Width="80" VerticalAlignment="Center" HorizontalAlignment="Left" TextAlignment="Right" TextChanged="TxtStartNumber_TextChanged" GotFocus="Txt_GotFocus_SelectAll"/>
+      <TextBox x:Name="txtParticipant" Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="1" Margin="5,0,5,0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" VerticalAlignment="Center" IsEnabled="False"/>
+      <Button x:Name="btnStore" Grid.Row="0" Grid.Column="3" Content="Zuweisen" Margin="5,0,5,0"  VerticalAlignment="Center" Click="BtnStore_Click"/>
     </Grid>
+  </Grid>
 </UserControl>

--- a/RaceHorology/MeasurementLogAndParticipantAssignment.xaml.cs
+++ b/RaceHorology/MeasurementLogAndParticipantAssignment.xaml.cs
@@ -68,6 +68,11 @@ namespace RaceHorology
       catch (Exception) { }
     }
 
-
+    private void dgParticipantAssigning_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+      if (dgParticipantAssigning.SelectedItem is Timestamp ts){
+        txtStartNumber.Text = ts.StartNumber.ToString();
+      }
+    }
   }
 }

--- a/RaceHorology/MeasurementLogAndParticipantAssignment.xaml.cs
+++ b/RaceHorology/MeasurementLogAndParticipantAssignment.xaml.cs
@@ -1,0 +1,34 @@
+﻿using RaceHorologyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace RaceHorology
+{
+  /// <summary>
+  /// Interaction logic for MeasurementLogAndParticipantAssignment.xaml
+  /// </summary>
+  public partial class MeasurementLogAndParticipantAssignment : UserControl
+  {
+    public MeasurementLogAndParticipantAssignment()
+    {
+      InitializeComponent();
+    }
+
+    public void SetLTPA(LiveTimeParticipantAssigning tdAssigning)
+    {
+      dgParticipantAssigning.ItemsSource = tdAssigning.Timestamps;
+    }
+  }
+}

--- a/RaceHorology/MeasurementLogAndParticipantAssignment.xaml.cs
+++ b/RaceHorology/MeasurementLogAndParticipantAssignment.xaml.cs
@@ -21,14 +21,53 @@ namespace RaceHorology
   /// </summary>
   public partial class MeasurementLogAndParticipantAssignment : UserControl
   {
+    private Race _race;
+    private LiveTimeParticipantAssigning _tdAssigning;
+
     public MeasurementLogAndParticipantAssignment()
     {
       InitializeComponent();
     }
 
-    public void SetLTPA(LiveTimeParticipantAssigning tdAssigning)
+    public void Init(LiveTimeParticipantAssigning tdAssigning, Race race)
     {
+      _race = race;
+      _tdAssigning = tdAssigning;
       dgParticipantAssigning.ItemsSource = tdAssigning.Timestamps;
     }
+
+    private void TxtStartNumber_TextChanged(object sender, TextChangedEventArgs e)
+    {
+      uint startNumber = 0U;
+      try { startNumber = uint.Parse(txtStartNumber.Text); } catch (Exception) { }
+      RaceParticipant participant = _race.GetParticipant(startNumber);
+      if (participant != null)
+      {
+        txtParticipant.Text = participant.Fullname;
+      }
+      else
+        txtParticipant.Text = "";
+    }
+
+    private void Txt_GotFocus_SelectAll(object sender, RoutedEventArgs e)
+    {
+      if (sender is TextBox txtbox)
+        txtbox.SelectAll();
+    }
+
+    private void BtnStore_Click(object sender, RoutedEventArgs e)
+    {
+      try 
+      { 
+        uint startNumber = uint.Parse(txtStartNumber.Text);
+        var ts = dgParticipantAssigning.SelectedItem as Timestamp;
+
+        if (ts != null)
+          _tdAssigning.Assign(ts, startNumber);
+      } 
+      catch (Exception) { }
+    }
+
+
   }
 }

--- a/RaceHorology/RaceHorology.csproj
+++ b/RaceHorology/RaceHorology.csproj
@@ -111,6 +111,9 @@
     <Compile Include="About.xaml.cs">
       <DependentUpon>About.xaml</DependentUpon>
     </Compile>
+    <Compile Include="MeasurementLogAndParticipantAssignment.xaml.cs">
+      <DependentUpon>MeasurementLogAndParticipantAssignment.xaml</DependentUpon>
+    </Compile>
     <Compile Include="TimingDeviceDebugDlg.xaml.cs">
       <DependentUpon>TimingDeviceDebugDlg.xaml</DependentUpon>
     </Compile>
@@ -196,6 +199,10 @@
     <Compile Include="UIUtilities.cs" />
     <Compile Include="ValueConverters.cs" />
     <Page Include="About.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="MeasurementLogAndParticipantAssignment.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/RaceHorology/RaceUC.xaml
+++ b/RaceHorology/RaceUC.xaml
@@ -661,7 +661,7 @@
                 </Grid.ColumnDefinitions>
                 <Label x:Name="lblParticipantAssigning" Content="Zeitstempel" HorizontalAlignment="Left" Margin="5,0,0,0" Grid.Row="0" VerticalAlignment="Top" FontSize="16"/>
               </Grid>
-              <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="1" AlternationCount="2" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+              <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="1" AlternationCount="2" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="True" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
                 <DataGrid.Style>
                   <Style TargetType="DataGrid">
                     <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>

--- a/RaceHorology/RaceUC.xaml
+++ b/RaceHorology/RaceUC.xaml
@@ -344,6 +344,8 @@
               <RowDefinition Height="2*"/>
               <RowDefinition Height="5"/>
               <RowDefinition Height="3*"/>
+              <RowDefinition Height="5"/>
+              <RowDefinition Height="3*"/>
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0">
@@ -464,7 +466,7 @@
                   </DataGrid.RowStyle>
                 </DataGrid>
               </Grid>
-              <Grid Grid.Row="3" >
+              <Grid Grid.Row="2" >
                 <Grid.ColumnDefinitions>
                   <ColumnDefinition Width="Auto"/>
                   <ColumnDefinition Width="Auto"/>
@@ -644,8 +646,30 @@
 
               </DataGrid>
             </Grid>
-          </Grid>
 
+            <GridSplitter x:Name="gridSplitter3" HorizontalAlignment="Stretch" Height="5" Grid.Row="5" />
+
+            <Grid Grid.Row="6">
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+              </Grid.RowDefinitions>
+              <Grid Width="Auto">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="*"/>
+                  <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Label x:Name="lblParticipantAssigning" Content="Zeitstempel" HorizontalAlignment="Left" Margin="5,0,0,0" Grid.Row="0" VerticalAlignment="Top" FontSize="16"/>
+              </Grid>
+              <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="1" AlternationCount="2" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+                <DataGrid.Style>
+                  <Style TargetType="DataGrid">
+                    <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
+                  </Style>
+                </DataGrid.Style>
+              </DataGrid>
+            </Grid>
+          </Grid>
         </Grid>
 
       </TabItem>
@@ -656,7 +680,7 @@
       </TabItem>
     </TabControl>
 
-    <GridSplitter x:Name="gridSplitter3" VerticalAlignment="Stretch" Width="5" Grid.Column="1" HorizontalAlignment="Center" />
+    <GridSplitter x:Name="gridSplitter4" VerticalAlignment="Stretch" Width="5" Grid.Column="1" HorizontalAlignment="Center" />
 
     <local:RaceListsUC x:Name="ucRaceLists" Grid.Column="2"/>
 

--- a/RaceHorology/RaceUC.xaml
+++ b/RaceHorology/RaceUC.xaml
@@ -344,7 +344,7 @@
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
-          <Grid Grid.Column="0">
+          <Grid Grid.Column="0" x:Name="grdTimingMain">
             <Grid.RowDefinitions>
               <RowDefinition Height="3*"/>
               <RowDefinition Height="5"/>
@@ -352,7 +352,7 @@
               <RowDefinition Height="5"/>
               <RowDefinition Height="3*"/>
               <RowDefinition Height="5"/>
-              <RowDefinition Height="3*"/>
+              <RowDefinition Height="2*"/>
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0">
@@ -656,7 +656,7 @@
 
             <GridSplitter x:Name="gridSplitter3" HorizontalAlignment="Stretch" Height="5" Grid.Row="5" />
 
-            <Grid Grid.Row="6">
+            <Grid x:Name="grdParticipantAssignment" Grid.Row="6">
               <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>

--- a/RaceHorology/RaceUC.xaml
+++ b/RaceHorology/RaceUC.xaml
@@ -671,21 +671,9 @@
                   <ColumnDefinition Width="1*"/>
                 </Grid.ColumnDefinitions>
                 <Label x:Name="lblParticipantAssigningStart" Content="Start" Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" FontSize="14"/>
-                <DataGrid x:Name="dgParticipantAssigningStart" Margin="5" Grid.Row="1"  Grid.Column="0" Grid.ColumnSpan="1" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="True" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
-                  <DataGrid.Style>
-                    <Style TargetType="DataGrid">
-                      <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
-                    </Style>
-                  </DataGrid.Style>
-                </DataGrid>
+                <local:MeasurementLogAndParticipantAssignment x:Name="mlapaStart" Grid.Row="1" Grid.Column="0" />
                 <Label x:Name="lblParticipantAssigningFinish" Content="Ziel" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" FontSize="14"/>
-                <DataGrid x:Name="dgParticipantAssigningFinish" Margin="5" Grid.Row="1" Grid.Column="1" AlternationCount="2" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="True" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
-                  <DataGrid.Style>
-                    <Style TargetType="DataGrid">
-                      <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
-                    </Style>
-                  </DataGrid.Style>
-                </DataGrid>
+                <local:MeasurementLogAndParticipantAssignment x:Name="mlapaFinish" Grid.Row="1" Grid.Column="1" />
               </Grid>
             </Grid>
           </Grid>

--- a/RaceHorology/RaceUC.xaml
+++ b/RaceHorology/RaceUC.xaml
@@ -656,18 +656,37 @@
               </Grid.RowDefinitions>
               <Grid Width="Auto">
                 <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="*"/>
-                  <ColumnDefinition Width="Auto"/>
+                  <ColumnDefinition Width="1*"/>
+                  <ColumnDefinition Width="1*"/>
                 </Grid.ColumnDefinitions>
-                <Label x:Name="lblParticipantAssigning" Content="Zeitstempel" HorizontalAlignment="Left" Margin="5,0,0,0" Grid.Row="0" VerticalAlignment="Top" FontSize="16"/>
+                <Label x:Name="lblParticipantAssigning" Content="Zeitmess-Protokoll" HorizontalAlignment="Left" Margin="5,0,0,0" Grid.Row="0" VerticalAlignment="Top" FontSize="16"/>
               </Grid>
-              <DataGrid x:Name="dgParticipantAssigning" Margin="5" Grid.Row="1" AlternationCount="2" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="True" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
-                <DataGrid.Style>
-                  <Style TargetType="DataGrid">
-                    <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
-                  </Style>
-                </DataGrid.Style>
-              </DataGrid>
+              <Grid Width="Auto" Grid.Row="6">
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="Auto"/>
+                  <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="1*"/>
+                  <ColumnDefinition Width="1*"/>
+                </Grid.ColumnDefinitions>
+                <Label x:Name="lblParticipantAssigningStart" Content="Start" Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" FontSize="14"/>
+                <DataGrid x:Name="dgParticipantAssigningStart" Margin="5" Grid.Row="1"  Grid.Column="0" Grid.ColumnSpan="1" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="True" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+                  <DataGrid.Style>
+                    <Style TargetType="DataGrid">
+                      <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
+                    </Style>
+                  </DataGrid.Style>
+                </DataGrid>
+                <Label x:Name="lblParticipantAssigningFinish" Content="Ziel" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" FontSize="14"/>
+                <DataGrid x:Name="dgParticipantAssigningFinish" Margin="5" Grid.Row="1" Grid.Column="1" AlternationCount="2" AlternatingRowBackground="#FFf8faf7" AutoGenerateColumns="True" CanUserAddRows="False" CanUserSortColumns="False" EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+                  <DataGrid.Style>
+                    <Style TargetType="DataGrid">
+                      <Setter Property="AlternatingRowBackground" Value="#FFf8faf7"/>
+                    </Style>
+                  </DataGrid.Style>
+                </DataGrid>
+              </Grid>
             </Grid>
           </Grid>
         </Grid>

--- a/RaceHorology/RaceUC.xaml.cs
+++ b/RaceHorology/RaceUC.xaml.cs
@@ -362,11 +362,16 @@ namespace RaceHorology
 
       _thisRace.RunsChanged += OnRaceRunsChanged;
 
+      int idx = 0;
       foreach(var td in _liveTimingMeasurement.GetTimingDevices())
       {
         if (td is LiveTimeParticipantAssigning tdAssigning)
         {
-          dgParticipantAssigning.ItemsSource = tdAssigning.Timestamps;
+          if (idx == 0)
+            dgParticipantAssigningStart.ItemsSource = tdAssigning.Timestamps;
+          if (idx == 1)
+            dgParticipantAssigningFinish.ItemsSource = tdAssigning.Timestamps;
+          idx++;
         }
       }
 

--- a/RaceHorology/RaceUC.xaml.cs
+++ b/RaceHorology/RaceUC.xaml.cs
@@ -368,9 +368,9 @@ namespace RaceHorology
         if (td is LiveTimeParticipantAssigning tdAssigning)
         {
           if (idx == 0)
-            mlapaStart.SetLTPA(tdAssigning);
+            mlapaStart.Init(tdAssigning, _thisRace);
           if (idx == 1)
-            mlapaFinish.SetLTPA(tdAssigning);
+            mlapaFinish.Init(tdAssigning, _thisRace);
           idx++;
         }
       }

--- a/RaceHorology/RaceUC.xaml.cs
+++ b/RaceHorology/RaceUC.xaml.cs
@@ -363,14 +363,14 @@ namespace RaceHorology
       _thisRace.RunsChanged += OnRaceRunsChanged;
 
       int idx = 0;
-      foreach(var td in _liveTimingMeasurement.GetTimingDevices())
+      foreach (var td in _liveTimingMeasurement.GetTimingDevices())
       {
         if (td is LiveTimeParticipantAssigning tdAssigning)
         {
           if (idx == 0)
-            dgParticipantAssigningStart.ItemsSource = tdAssigning.Timestamps;
+            mlapaStart.SetLTPA(tdAssigning);
           if (idx == 1)
-            dgParticipantAssigningFinish.ItemsSource = tdAssigning.Timestamps;
+            mlapaFinish.SetLTPA(tdAssigning);
           idx++;
         }
       }

--- a/RaceHorology/RaceUC.xaml.cs
+++ b/RaceHorology/RaceUC.xaml.cs
@@ -72,6 +72,7 @@ namespace RaceHorology
       _thisRace = race;
       _liveTimingMeasurement = liveTimingMeasurement;
       _liveTimingMeasurement.LiveTimingMeasurementStatusChanged += OnLiveTimingMeasurementStatusChanged;
+      _liveTimingMeasurement.LiveTimingConfigChanged += OnLiveTimingMeasurementConfigChanged;
 
       _txtLiveTimingStatus = txtLiveTimingStatus;
       _txtLiveTimingStatus.TextChanged += new DelayedEventHandler(
@@ -362,6 +363,11 @@ namespace RaceHorology
 
       _thisRace.RunsChanged += OnRaceRunsChanged;
 
+      InitializeTiming2();
+    }
+
+    private void InitializeTiming2()
+    {
       int idx = 0;
       foreach (var td in _liveTimingMeasurement.GetTimingDevices())
       {
@@ -376,6 +382,11 @@ namespace RaceHorology
       }
 
       UpdateLiveTimingStartStopButtons(false); // Initial status
+    }
+
+    private void OnLiveTimingMeasurementConfigChanged(object sender, bool changed)
+    {
+      InitializeTiming2();
     }
 
 

--- a/RaceHorology/RaceUC.xaml.cs
+++ b/RaceHorology/RaceUC.xaml.cs
@@ -401,6 +401,8 @@ namespace RaceHorology
 
     private void InitializeTiming2()
     {
+      bool showParticipantAssignment = false;
+
       int idx = 0;
       foreach (var td in _liveTimingMeasurement.GetTimingDevices())
       {
@@ -412,9 +414,22 @@ namespace RaceHorology
             mlapaFinish.Init(tdAssigning, _thisRace);
           idx++;
         }
+        if (td is TimingDeviceAlpenhunde)
+          showParticipantAssignment = true;
       }
 
       UpdateLiveTimingStartStopButtons(false); // Initial status
+
+      if (showParticipantAssignment)
+      {
+        grdTimingMain.RowDefinitions[5].Height = new GridLength(5);
+        grdTimingMain.RowDefinitions[6].Height = new GridLength(3, GridUnitType.Star);
+      }
+      else
+      {
+        grdTimingMain.RowDefinitions[5].Height = new GridLength(0);
+        grdTimingMain.RowDefinitions[6].Height = new GridLength(0);
+      }
     }
 
     private void OnLiveTimingMeasurementConfigChanged(object sender, bool changed)

--- a/RaceHorology/RaceUC.xaml.cs
+++ b/RaceHorology/RaceUC.xaml.cs
@@ -362,6 +362,14 @@ namespace RaceHorology
 
       _thisRace.RunsChanged += OnRaceRunsChanged;
 
+      foreach(var td in _liveTimingMeasurement.GetTimingDevices())
+      {
+        if (td is LiveTimeParticipantAssigning tdAssigning)
+        {
+          dgParticipantAssigning.ItemsSource = tdAssigning.Timestamps;
+        }
+      }
+
       UpdateLiveTimingStartStopButtons(false); // Initial status
     }
 

--- a/RaceHorologyLib/ALGETdC8001TimeMeasurement.cs
+++ b/RaceHorologyLib/ALGETdC8001TimeMeasurement.cs
@@ -153,7 +153,6 @@ namespace RaceHorologyLib
 
       // Sort out invalid data
       if ( parsedData.Flag == 'p'
-        || parsedData.Flag == '?'
         || parsedData.Flag == 'b'
         || parsedData.Flag == 'm'
         || parsedData.Flag == 'n'
@@ -164,6 +163,7 @@ namespace RaceHorologyLib
         || parsedData.Flag == 'c')
         parsedDataTime = null;
 
+      data.Valid = parsedData.Flag != '?';
       data.StartNumber = parsedData.StartNumber;
 
       switch (parsedData.Channel)

--- a/RaceHorologyLib/AppDataModelDataTypes.cs
+++ b/RaceHorologyLib/AppDataModelDataTypes.cs
@@ -982,6 +982,7 @@ namespace RaceHorologyLib
       NotifyPropertyChanged(propertyName: nameof(Runtime));
     }
 
+
     public virtual TimeSpan? GetRunTime(bool calculateIfNotStored = true, bool considerResultCode = true)
     {
       if (!considerResultCode || _resultCode == EResultCode.Normal)
@@ -1015,6 +1016,10 @@ namespace RaceHorologyLib
       if (_resultCode == EResultCode.NotSet)
         _resultCode = EResultCode.Normal;
 
+      // Delete RunTime if it was set to enusre consistency
+      if (_runTime != null)
+        _runTime = null;
+
       NotifyPropertyChanged(propertyName: nameof(StartTime));
       NotifyPropertyChanged(propertyName: nameof(Runtime));
     }
@@ -1028,6 +1033,10 @@ namespace RaceHorologyLib
 
       if (_resultCode == EResultCode.NotSet)
         _resultCode = EResultCode.Normal;
+
+      // Delete RunTime if it was set to enusre consistency
+      if (_runTime != null)
+        _runTime = null;
 
       NotifyPropertyChanged(propertyName: nameof(FinishTime));
       NotifyPropertyChanged(propertyName: nameof(Runtime));

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -129,7 +129,9 @@ namespace RaceHorologyLib
 
       // Trigger TimeMeasurementReceived event with updated startnumber
       var handle = TimeMeasurementReceived;
-      handle?.Invoke(this, createTimeMeasurement(timestamp));
+      var newEvent = createTimeMeasurement(timestamp);
+      newEvent.Valid = true; // Make this event a valid one, because it's intended to be (manuelly triggered)
+      handle?.Invoke(this, newEvent);
     }
 
     private TimeMeasurementEventArgs createTimeMeasurement(Timestamp timestamp)

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -12,18 +12,24 @@ namespace RaceHorologyLib
   public class Timestamp : INotifyPropertyChanged
   {
     private Timestamp _timeStamp;
+    private TimeMeasurementEventArgs _orgTimeData;
     private uint _startnumber;
 
-    public Timestamp(Timestamp timeStamp, uint startnumber = 0, RaceParticipant participant = null)
+    public Timestamp(Timestamp timeStamp, TimeMeasurementEventArgs orgTimeData, uint startnumber = 0, RaceParticipant participant = null)
     {
       _timeStamp = timeStamp;
+      _orgTimeData = orgTimeData;
       _startnumber = startnumber;
     }
 
     public Timestamp Time
     {
       get => _timeStamp;
-      set { if (_timeStamp != value) { _timeStamp = value; NotifyPropertyChanged(); } }
+    }
+
+    public TimeMeasurementEventArgs OrgTimeData
+    {
+      get => _orgTimeData;
     }
 
     public uint StartNumber

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -13,13 +13,11 @@ namespace RaceHorologyLib
   {
     private Timestamp _timeStamp;
     private uint _startnumber;
-    private RaceParticipant _participant;
 
     public Timestamp(Timestamp timeStamp, uint startnumber = 0, RaceParticipant participant = null)
     {
       _timeStamp = timeStamp;
       _startnumber = startnumber;
-      _participant = participant;
     }
 
     public Timestamp Time
@@ -32,11 +30,6 @@ namespace RaceHorologyLib
     {
       get => _startnumber;
       set { if (_startnumber != value) { _startnumber = value; NotifyPropertyChanged(); } }
-    }
-    public RaceParticipant Participant
-    {
-      get => _participant;
-      set { if (_participant != value) { _participant = value; NotifyPropertyChanged(); } }
     }
 
 

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -32,6 +32,11 @@ namespace RaceHorologyLib
       get => _orgTimeData;
     }
 
+    public bool Valid
+    {
+      get => _orgTimeData.Valid;
+    }
+
     public uint StartNumber
     {
       get => _startnumber;

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -55,15 +55,18 @@ namespace RaceHorologyLib
 
   public class LiveTimeParticipantAssigning : ILiveTimeMeasurementDeviceBase, IDisposable
   {
+    public enum EMeasurementPoint { Undefined, Start, Finish };
     private ILiveTimeMeasurementDevice _timeMeasurementDevice;
+    private EMeasurementPoint _measurementPoint;
     private ItemsChangeObservableCollection<Timestamp> _timestamps;
     private System.Threading.SynchronizationContext _syncContext;
 
-    public LiveTimeParticipantAssigning(ILiveTimeMeasurementDevice timeMeasurementDevice)
+    public LiveTimeParticipantAssigning(ILiveTimeMeasurementDevice timeMeasurementDevice, EMeasurementPoint measurementPoint)
     {
       _syncContext = System.Threading.SynchronizationContext.Current;
 
       _timeMeasurementDevice = timeMeasurementDevice;
+      _measurementPoint = measurementPoint;
       _timestamps = new ItemsChangeObservableCollection<Timestamp>();
 
       _timeMeasurementDevice.TimeMeasurementReceived += timeMeasurementDevice_TimeMeasurementReceived;
@@ -79,8 +82,10 @@ namespace RaceHorologyLib
     {
       _syncContext.Send(delegate
       {
+        var measurementPoint = e.BStartTime ? EMeasurementPoint.Start: e.BFinishTime ? EMeasurementPoint.Finish : EMeasurementPoint.Undefined;
         var time = e.BStartTime ? e.StartTime : e.BFinishTime ? e.FinishTime : null;
-        if (time != null)
+        if ( (_measurementPoint == EMeasurementPoint.Undefined || measurementPoint == _measurementPoint) 
+             && time != null)
         {
           var ts = new Timestamp((TimeSpan)time, e, e.StartNumber);
 

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -83,9 +83,20 @@ namespace RaceHorologyLib
         if (time != null)
         {
           var ts = new Timestamp((TimeSpan)time, e, e.StartNumber);
+
+          ts.PropertyChanged += timeStamp_PropertyChanged;
+
           _timestamps.Add(ts);
         }
       }, null);
+    }
+
+    private void timeStamp_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+      if (sender is Timestamp ts)
+      {
+        NotifyChange(ts, ts.StartNumber);
+      }
     }
 
     public ItemsChangeObservableCollection<Timestamp> Timestamps
@@ -93,17 +104,10 @@ namespace RaceHorologyLib
       get { return _timestamps; }
     }
 
-    public void Assign(Timestamp timestamp, uint startnumber)
+    public void NotifyChange(Timestamp timestamp, uint startnumber)
     {
       if (_timestamps.FirstOrDefault(item => item == timestamp) == null) // Just check whether the item is in the container
         return;
-
-      // Check if the startnumber is already used by another timestamp
-      var inUse = startnumber == 0 ? null : _timestamps.FirstOrDefault(item => item.StartNumber == startnumber);
-      if (inUse != null && inUse != timestamp)
-        inUse.StartNumber = 0;
-
-      timestamp.StartNumber = startnumber;
 
       // Trigger TimeMeasurementReceived event with updated startnumber
       var handle = TimeMeasurementReceived;

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaceHorologyLib
+{
+  internal class LiveTimeParticipantAssigning
+  {
+  }
+}

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -1,12 +1,60 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace RaceHorologyLib
 {
-  internal class LiveTimeParticipantAssigning
+
+  public class Timestamp : INotifyPropertyChanged
+  {
+    private Timestamp _timeStamp;
+    private uint _startnumber;
+    private RaceParticipant _participant;
+
+    public Timestamp(Timestamp timeStamp, uint startnumber = 0, RaceParticipant participant = null)
+    {
+      _timeStamp = timeStamp;
+      _startnumber = startnumber;
+      _participant = participant;
+    }
+
+    public Timestamp Time
+    {
+      get => _timeStamp;
+      set { if (_timeStamp != value) { _timeStamp = value; NotifyPropertyChanged(); } }
+    }
+
+    public uint StartNumber
+    {
+      get => _startnumber;
+      set { if (_startnumber != value) { _startnumber = value; NotifyPropertyChanged(); } }
+    }
+    public RaceParticipant Participant
+    {
+      get => _participant;
+      set { if (_participant != value) { _participant = value; NotifyPropertyChanged(); } }
+    }
+
+
+    #region INotifyPropertyChanged implementation
+
+    public event PropertyChangedEventHandler PropertyChanged;
+    // This method is called by the Set accessor of each property.  
+    // The CallerMemberName attribute that is applied to the optional propertyName  
+    // parameter causes the property name of the caller to be substituted as an argument.  
+    private void NotifyPropertyChanged([CallerMemberName] String propertyName = "")
+    {
+      PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    #endregion
+  }
+
+  public class LiveTimeParticipantAssigning
   {
   }
 }

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -53,6 +53,16 @@ namespace RaceHorologyLib
     #endregion
   }
 
+
+  internal class TimestampComparerDesc : IComparer<Timestamp>
+  {
+    public int Compare(Timestamp a, Timestamp b)
+    {
+      return b.Time.CompareTo(a.Time);
+    }
+  }
+
+
   public class LiveTimeParticipantAssigning : ILiveTimeMeasurementDeviceBase, IDisposable
   {
     public enum EMeasurementPoint { Undefined, Start, Finish };
@@ -60,6 +70,8 @@ namespace RaceHorologyLib
     private EMeasurementPoint _measurementPoint;
     private ItemsChangeObservableCollection<Timestamp> _timestamps;
     private System.Threading.SynchronizationContext _syncContext;
+
+    private IComparer<Timestamp> _sorter = new TimestampComparerDesc();
 
     public LiveTimeParticipantAssigning(ILiveTimeMeasurementDevice timeMeasurementDevice, EMeasurementPoint measurementPoint)
     {
@@ -91,7 +103,8 @@ namespace RaceHorologyLib
 
           ts.PropertyChanged += timeStamp_PropertyChanged;
 
-          _timestamps.Add(ts);
+          _timestamps.Insert(0, ts);
+          _timestamps.Sort<Timestamp>(_sorter);
         }
       }, null);
     }

--- a/RaceHorologyLib/LiveTimeParticipantAssigning.cs
+++ b/RaceHorologyLib/LiveTimeParticipantAssigning.cs
@@ -58,7 +58,7 @@ namespace RaceHorologyLib
     private ILiveTimeMeasurementDevice _timeMeasurementDevice;
     private ItemsChangeObservableCollection<Timestamp> _timestamps;
 
-    LiveTimeParticipantAssigning(ILiveTimeMeasurementDevice timeMeasurementDevice)
+    public LiveTimeParticipantAssigning(ILiveTimeMeasurementDevice timeMeasurementDevice)
     {
       _timeMeasurementDevice = timeMeasurementDevice;
       _timestamps = new ItemsChangeObservableCollection<Timestamp>();

--- a/RaceHorologyLib/LiveTimingMeasurement.cs
+++ b/RaceHorologyLib/LiveTimingMeasurement.cs
@@ -287,6 +287,11 @@ namespace RaceHorologyLib
       }
     }
 
+    public List<ILiveTimeMeasurementDeviceBase> GetTimingDevices()
+    {
+      return _timingDevices;
+    }
+
 
     /// <summary>
     /// Property to get the used timing device

--- a/RaceHorologyLib/LiveTimingMeasurement.cs
+++ b/RaceHorologyLib/LiveTimingMeasurement.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (C) 2019 - 2022 by Sven Flossmann
  *  
  *  This file is part of Race Horology.
@@ -62,6 +62,17 @@ namespace RaceHorologyLib
       BStartTime = false;
       FinishTime = null;
       BFinishTime = false;
+    }
+
+    public TimeMeasurementEventArgs(TimeMeasurementEventArgs org)
+    {
+      StartNumber = org.StartNumber;
+      RunTime = org.RunTime;
+      BRunTime = org.BRunTime;
+      StartTime = org.StartTime;
+      BStartTime = org.BStartTime;
+      FinishTime = org.FinishTime;
+      BFinishTime = org.BFinishTime;
     }
 
     public uint StartNumber;

--- a/RaceHorologyLib/LiveTimingMeasurement.cs
+++ b/RaceHorologyLib/LiveTimingMeasurement.cs
@@ -235,6 +235,9 @@ namespace RaceHorologyLib
     public delegate void LiveTimingMeasurementStatusEventHandler(object sender, bool isRunning);
     public event LiveTimingMeasurementStatusEventHandler LiveTimingMeasurementStatusChanged;
 
+    public delegate void LiveTimingMeasurementConfigChangedEventHandler(object sender, bool configChanged);
+    public event LiveTimingMeasurementConfigChangedEventHandler LiveTimingConfigChanged;
+
 
     /// <summary>
     /// Sets the Timing Device to use
@@ -270,6 +273,9 @@ namespace RaceHorologyLib
       }
 
       _timingDevices.Add(timingDevice);
+
+      var handler = LiveTimingConfigChanged;
+      handler?.Invoke(this, true);
     }
 
     public void RemoveTimingDevice(ILiveTimeMeasurementDeviceBase timingDevice)
@@ -287,6 +293,8 @@ namespace RaceHorologyLib
         }
         _timingDevices.Remove(timingDevice);
 
+        var handler = LiveTimingConfigChanged;
+        handler?.Invoke(this, true);
       }
     }
 

--- a/RaceHorologyLib/LiveTimingMeasurement.cs
+++ b/RaceHorologyLib/LiveTimingMeasurement.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (C) 2019 - 2022 by Sven Flossmann
  *  
  *  This file is part of Race Horology.
@@ -105,17 +105,23 @@ namespace RaceHorologyLib
   public delegate void LiveTimingMeasurementDeviceStatusEventHandler(object sender, bool isRunning);
 
 
-  /// <summary>
-  /// This Interface must be implemented from a Live Timing Measurement Device which supports online time measurement during the race.
-  /// Most favourit device for now are the ALGE TdC8000/TdC8001 or ALGE Timy
-  /// </summary>
-  public interface ILiveTimeMeasurementDevice
+
+  public interface ILiveTimeMeasurementDeviceBase
   {
     /// <summary>
     /// If a time measurement happend, this event must be triggered.
     /// </summary>
     event TimeMeasurementEventHandler TimeMeasurementReceived;
 
+  }
+
+
+  /// <summary>
+  /// This Interface must be implemented from a Live Timing Measurement Device which supports online time measurement during the race.
+  /// Most favourit device for now are the ALGE TdC8000/TdC8001 or ALGE Timy
+  /// </summary>
+  public interface ILiveTimeMeasurementDevice : ILiveTimeMeasurementDeviceBase
+  {
     /// <summary>
     /// If a startnumber has been selected - entered via keyboard of the device - this event is triggered.
     /// </summary>

--- a/RaceHorologyLib/LiveTimingMeasurement.cs
+++ b/RaceHorologyLib/LiveTimingMeasurement.cs
@@ -62,6 +62,7 @@ namespace RaceHorologyLib
       BStartTime = false;
       FinishTime = null;
       BFinishTime = false;
+      Valid = false;
     }
 
     public TimeMeasurementEventArgs(TimeMeasurementEventArgs org)
@@ -73,6 +74,7 @@ namespace RaceHorologyLib
       BStartTime = org.BStartTime;
       FinishTime = org.FinishTime;
       BFinishTime = org.BFinishTime;
+      Valid = org.Valid;
     }
 
     public uint StartNumber;
@@ -82,6 +84,7 @@ namespace RaceHorologyLib
     public bool BStartTime;      // true if StartTime is set
     public TimeSpan? FinishTime; // if null and corresponding time property is set true => time shall be deleted
     public bool BFinishTime;     // true if FinishTime is set
+    public bool Valid;           // true if timestamp is valid, false if time measurementdevice marked it as invalid
   }
 
   public class StartnumberSelectedEventArgs: EventArgs
@@ -338,6 +341,10 @@ namespace RaceHorologyLib
     private void OnTimeMeasurementReceived(object sender, TimeMeasurementEventArgs e)
     {
       if (!_isRunning)
+        return;
+
+      // Only accept valid timemeasurements
+      if (!e.Valid) 
         return;
 
       _syncContext.Send(delegate

--- a/RaceHorologyLib/RaceHorologyLib.csproj
+++ b/RaceHorologyLib/RaceHorologyLib.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Import.cs" />
     <Compile Include="ImportTime.cs" />
     <Compile Include="JsonConversion.cs" />
+    <Compile Include="LiveTimeParticipantAssigning.cs" />
     <Compile Include="LiveTiming.cs" />
     <Compile Include="LiveTimingMeasurement.cs" />
     <Compile Include="ObjectExtensions.cs" />

--- a/RaceHorologyLib/TimingDeviceAlpenhunde.cs
+++ b/RaceHorologyLib/TimingDeviceAlpenhunde.cs
@@ -151,6 +151,8 @@ namespace RaceHorologyLib
       Logger.Info("Stop()");
       if (_webSocket != null)
         _webSocket.Close();
+
+      _webSocket = null;
     }
 
 

--- a/RaceHorologyLib/TimingDeviceAlpenhunde.cs
+++ b/RaceHorologyLib/TimingDeviceAlpenhunde.cs
@@ -213,6 +213,7 @@ namespace RaceHorologyLib
       data.Index = parsedData.i;
 
       data.StartNumber = startNumber;
+      data.Valid = startNumber > 0;
       switch (parsedData.c)
       {
         case 1: // Start

--- a/RaceHorologyLibTest/ALGETdC8001Tests.cs
+++ b/RaceHorologyLibTest/ALGETdC8001Tests.cs
@@ -763,7 +763,8 @@ namespace RaceHorologyLibTest
         LiveTimingMeasurement liveTimingMeasurement = new LiveTimingMeasurement(modelWork);
 
         ALGETdC8001TimeMeasurementSimulate algeSimulator = new ALGETdC8001TimeMeasurementSimulate(testfile);
-        liveTimingMeasurement.SetTimingDevice(algeSimulator, algeSimulator);
+        liveTimingMeasurement.AddTimingDevice(algeSimulator, true);
+        liveTimingMeasurement.SetLiveDateTimeProvider(algeSimulator);
         algeSimulator.Start();
 
         modelWork.SetCurrentRaceRun(modelWork.GetRace(0).GetRun(run));

--- a/RaceHorologyLibTest/ALGETdC8001Tests.cs
+++ b/RaceHorologyLibTest/ALGETdC8001Tests.cs
@@ -544,6 +544,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 21, 46, 36, 390), pd.StartTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       {
@@ -553,6 +554,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 21, 46, 36, 391), pd.StartTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       {
@@ -562,6 +564,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 0, 0, 20, 100), pd.RunTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BStartTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       { // Disqualified
@@ -571,6 +574,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(null, pd.StartTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
       { // Cleared data
         var pd = ParseAndTransfer("c0035 C0  21:46:36.3910 00");
@@ -579,12 +583,20 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(null, pd.StartTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       // Ignored data (first character)
       { // Invalid startnumber
         var pd = ParseAndTransfer("?0034 C1M 21:46:48.3300 00");
-        Assert.IsNull(pd);
+        Assert.AreEqual(34U, pd.StartNumber);
+        Assert.AreEqual(false, pd.BStartTime);
+        Assert.AreEqual(null, pd.StartTime);
+        Assert.AreEqual(true, pd.BFinishTime);
+        Assert.AreEqual(new TimeSpan(0, 21, 46, 48, 330), pd.FinishTime);
+        Assert.AreEqual(false, pd.BRunTime);
+        Assert.AreEqual(null, pd.RunTime);
+        Assert.IsFalse(pd.Valid);
       }
       { // penalty time (parallelslalom)
         var pd = ParseAndTransfer("p0034 C1M 21:46:48.3300 00");
@@ -627,6 +639,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 19, 52, 15, 162), pd.StartTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       {
@@ -636,6 +649,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 19, 52, 15, 162), pd.StartTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       {
@@ -645,6 +659,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 19, 52, 20, 390), pd.FinishTime);
         Assert.AreEqual(false, pd.BStartTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       {
@@ -654,6 +669,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 19, 52, 23, 401), pd.FinishTime);
         Assert.AreEqual(false, pd.BStartTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       {
@@ -663,6 +679,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 0, 0, 5, 220), pd.RunTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BStartTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       {
@@ -672,6 +689,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(new TimeSpan(0, 0, 0, 8, 230), pd.RunTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BStartTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       { // Disqualified
@@ -681,6 +699,7 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(null, pd.StartTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
       { // Cleared data
         var pd = ParseAndTransfer("c0035 C0  21:46:36.3910 00");
@@ -689,12 +708,20 @@ namespace RaceHorologyLibTest
         Assert.AreEqual(null, pd.StartTime);
         Assert.AreEqual(false, pd.BFinishTime);
         Assert.AreEqual(false, pd.BRunTime);
+        Assert.IsTrue(pd.Valid);
       }
 
       // Ignored data (first character)
       { // Invalid startnumber
         var pd = ParseAndTransfer("?0034 C1M 21:46:48.3300 00");
-        Assert.IsNull(pd);
+        Assert.AreEqual(34U, pd.StartNumber);
+        Assert.AreEqual(false, pd.BStartTime);
+        Assert.AreEqual(null, pd.StartTime);
+        Assert.AreEqual(true, pd.BFinishTime);
+        Assert.AreEqual(new TimeSpan(0, 21, 46, 48, 330), pd.FinishTime);
+        Assert.AreEqual(false, pd.BRunTime);
+        Assert.AreEqual(null, pd.RunTime);
+        Assert.IsFalse(pd.Valid);
       }
       { // penalty time (parallelslalom)
         var pd = ParseAndTransfer("p0034 C1M 21:46:48.3300 00");


### PR DESCRIPTION
Die Funktion ist im Moment nur für Alpenhunde verfügbar.