### PR TITLE
Feature: Füge Export für RaceEngine hinzu

### DIFF
--- a/RaceHorology/MainWindow.xaml.cs
+++ b/RaceHorology/MainWindow.xaml.cs
@@ -675,9 +675,9 @@ namespace RaceHorology
       List<ExportConfig> exportConfigs = new List<ExportConfig> {
         { new ExportConfig { Name = "DSV (XML Format)", ExportFunc = ExportUI.ExportDsv } },
         { new ExportConfig { Name = "RaceEngine (ZIP Format)", ExportFunc = ExportUI.ExportRaceEngine } },
-        { new ExportConfig { Name = "Excel Export", ExportFunc = ExportUI.ExportXLSX } },
-        { new ExportConfig { Name = "CSV - Export", ExportFunc = ExportUI.ExportCSV } },
         { new ExportConfig { Name = "rennmeldung.de", ExportFunc = ExportUI.ExportDsvAlpin } },
+        { new ExportConfig { Name = "Excel", ExportFunc = ExportUI.ExportXLSX } },
+        { new ExportConfig { Name = "CSV", ExportFunc = ExportUI.ExportCSV } },
         { new ExportConfig { Name = "DSV-Alpin (altes Format)", ExportFunc = ExportUI.ExportDsvAlpin } },
       };
 

--- a/RaceHorology/MainWindow.xaml.cs
+++ b/RaceHorology/MainWindow.xaml.cs
@@ -674,6 +674,7 @@ namespace RaceHorology
     {
       List<ExportConfig> exportConfigs = new List<ExportConfig> {
         { new ExportConfig { Name = "DSV (XML Format)", ExportFunc = ExportUI.ExportDsv } },
+        { new ExportConfig { Name = "RaceEngine (ZIP Format)", ExportFunc = ExportUI.ExportRaceEngine } },
         { new ExportConfig { Name = "Excel Export", ExportFunc = ExportUI.ExportXLSX } },
         { new ExportConfig { Name = "CSV - Export", ExportFunc = ExportUI.ExportCSV } },
         { new ExportConfig { Name = "rennmeldung.de", ExportFunc = ExportUI.ExportDsvAlpin } },

--- a/RaceHorology/NLog.config
+++ b/RaceHorology/NLog.config
@@ -34,7 +34,7 @@
     <logger name="LiveTimingRM"                               minlevel="Debug" writeTo="logfile-rm-livetiming" />
     <logger name="RaceHorologyLib.ALGETdC8001TimeMeasurement" minlevel="Debug" writeTo="logfile-alge" />
     <logger name="RaceHorologyLib.TimingDeviceAlpenhunde"     minlevel="Debug" writeTo="logfile-alpenhunde" />
-    <logger name="*"                                          minlevel="Info"  writeTo="logfile" />
+    <logger name="*"                                          minlevel="Debug"  writeTo="logfile" />
     <logger name="*"                                          minlevel="Debug" writeTo="logconsole" />
   </rules>
 </nlog>


### PR DESCRIPTION
Der Export ist im grundegenommen nur eine gezippte Bewerbsdatei, aber erlaubt es die Datei direkt zu erstellen ohne Windows Boardmittel zu benötigen. Aktuell gibt es User die für diesen Export Extra noch DSVAlpin bemühen (hier existiert diese Funktion). 