### PR TITLE
Unterstützung von aktualisierenden Imports

### DIFF
--- a/RaceHorology/ImportWizard.xaml
+++ b/RaceHorology/ImportWizard.xaml
@@ -38,13 +38,16 @@
         <RowDefinition Height="*"/>
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
       </Grid.RowDefinitions>
 
       <Label Content="Feld-Zuordnung:" Grid.Row="0" Grid.Column="0" FontSize="16"/>
       <local:MappingUC x:Name="mappingUC" Grid.Row="1" Grid.Column="0" />
 
-      <Label Content="Rennen:" Grid.Row="2" FontSize="16"/>
-      <ListBox x:Name="lbRaces" Grid.Row="3" />
+      <CheckBox x:Name="chkOnlyUpdateExisting" Content="Bestehende Teilnehmer nur aktualisieren"  Margin="0,5" Grid.Row="2" />
+
+      <Label Content="Rennen:" Grid.Row="3" FontSize="16"/>
+      <ListBox x:Name="lbRaces" Grid.Row="4" />
     </Grid>
 
     

--- a/RaceHorology/ImportWizard.xaml.cs
+++ b/RaceHorology/ImportWizard.xaml.cs
@@ -121,7 +121,7 @@ namespace RaceHorology
             messageTextDetails += string.Format(
               "Zusammenfassung für das Rennen {0}:\n" +
               "- Erfolgreich importierte Teilnehmer: {1}\n" +
-              "- Übersprungene Teilnehmer: {2}\n",
+              "- Übersprungene Teilnehmer: {2}\n" +
               "- Fehlerhafte Teilnehmer (nicht importiert): {3}\n\n",
               race.ToString(), results.SuccessCount, results.SkipCount, results.ErrorCount);
           }
@@ -136,7 +136,7 @@ namespace RaceHorology
         messageTextDetails += string.Format(
           "Zusammenfassung für den allgemeinen Teilnehmerimport:\n" +
           "- Erfolgreich importierte Teilnehmer: {0}\n" +
-          "- Übersprungene Teilnehmer: {1}\n",
+          "- Übersprungene Teilnehmer: {1}\n" +
           "- Fehlerhafte Teilnehmer (nicht importiert): {2}\n\n",
           results.SuccessCount, results.SkipCount, results.ErrorCount);
       }

--- a/RaceHorologyLib/AppDataModel.cs
+++ b/RaceHorologyLib/AppDataModel.cs
@@ -40,7 +40,6 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Windows.Data;
 using WebSocketSharp;
 
 namespace RaceHorologyLib
@@ -62,7 +61,7 @@ namespace RaceHorologyLib
 
     ObservableCollection<ParticipantGroup> _particpantGroups;
     DatabaseDelegatorGroups _particpantGroupsDelegatorDB;
-    
+
     ObservableCollection<ParticipantClass> _particpantClasses;
     DatabaseDelegatorClasses _particpantClassesDelegatorDB;
 
@@ -89,7 +88,7 @@ namespace RaceHorologyLib
 
     private Dictionary<Participant, DateTime> _interactiveTimeMeasurements; // Contains the time measurements made interactively
 
-    public class CurrentRaceEventArgs :  EventArgs
+    public class CurrentRaceEventArgs : EventArgs
     {
       public Race CurrentRace { get; set; }
       public RaceRun CurrentRaceRun { get; set; }
@@ -355,16 +354,16 @@ namespace RaceHorologyLib
 
     public RaceConfiguration GlobalRaceConfig
     {
-      get 
-      { 
-        return _globalRaceConfig; 
+      get
+      {
+        return _globalRaceConfig;
       }
-      
-      set 
-      { 
-        _globalRaceConfig = value.Copy(); 
-        storeRaceConfig(); 
-        NotifyPropertyChanged(); 
+
+      set
+      {
+        _globalRaceConfig = value.Copy();
+        storeRaceConfig();
+        NotifyPropertyChanged();
       }
     }
 
@@ -420,11 +419,11 @@ namespace RaceHorologyLib
           dsvAlpinDB.UpdateCompetitionProperties(compProps);
 
           // Enusre that the bewerbsnummer is set correctly
-          if ( compProps.Type == CompetitionProperties.ECompetitionType.DSV_Points 
+          if (compProps.Type == CompetitionProperties.ECompetitionType.DSV_Points
             || compProps.Type == CompetitionProperties.ECompetitionType.DSV_NoPoints
             || compProps.Type == CompetitionProperties.ECompetitionType.DSV_SchoolPoints
-            || compProps.Type == CompetitionProperties.ECompetitionType.DSV_SchoolNoPoints )
-          dsvAlpinDB.EnsureDSVAlpinBewerbsnummer( _races );
+            || compProps.Type == CompetitionProperties.ECompetitionType.DSV_SchoolNoPoints)
+            dsvAlpinDB.EnsureDSVAlpinBewerbsnummer(_races);
         }
       }
     }
@@ -476,7 +475,7 @@ namespace RaceHorologyLib
     {
       void removeGroupFromClasses(ParticipantGroup g)
       {
-        foreach(var c in _particpantClasses)
+        foreach (var c in _particpantClasses)
           if (c.Group == g)
             c.Group = null;
       }
@@ -808,8 +807,9 @@ namespace RaceHorologyLib
     }
 
     string _timingDevice;
-    public string TimingDevice {
-      get { return _timingDevice; } 
+    public string TimingDevice
+    {
+      get { return _timingDevice; }
       protected set
       {
         if (_timingDevice != value)
@@ -822,12 +822,12 @@ namespace RaceHorologyLib
 
     public RaceConfiguration RaceConfiguration
     {
-      get 
-      { 
+      get
+      {
         return _raceConfiguration;
       }
-      
-      set 
+
+      set
       {
         if (value != null)
         {
@@ -905,7 +905,7 @@ namespace RaceHorologyLib
       _raceParticipantDBDelegator = new DatabaseDelegatorRaceParticipant(this, _db);
       // Store and Race related things
       _raceDBDelegator = new DatabaseDelegatorRace(this, db);
-      
+
       ViewConfigurator viewConfigurator = new ViewConfigurator(this);
       viewConfigurator.ConfigureRace(this);
     }
@@ -1124,7 +1124,7 @@ namespace RaceHorologyLib
     {
       if (0 <= run && run < GetMaxRun())
         return _runs.ElementAt(run).Item1;
-      
+
       throw new Exception("invalid race run in GetRun()");
     }
 
@@ -1151,7 +1151,7 @@ namespace RaceHorologyLib
       // First run does not have a previous run
       if (i == 0)
         return null;
-      
+
       --i;
       return _runs[i].Item1;
     }
@@ -1191,7 +1191,7 @@ namespace RaceHorologyLib
     /// </summary>
     /// <param name="participant">The particpant to add</param>
     /// <returns>The the corresponding RaceParticipant object</returns>
-    public RaceParticipant AddParticipant(Participant participant, uint startnumber= 0, double points = -1)
+    public RaceParticipant AddParticipant(Participant participant, uint startnumber = 0, double points = -1)
     {
       if (points == -1)
       {
@@ -1221,6 +1221,11 @@ namespace RaceHorologyLib
           var rr = _db.GetRaceRun(this, run.Run).FindAll(r => r.Participant.Participant == participant);
           run.InsertResults(rr);
         }
+      }
+      else
+      {
+        raceParticipant.Points = points;
+        raceParticipant.StartNumber = startnumber;
       }
 
       return raceParticipant;
@@ -1362,7 +1367,7 @@ namespace RaceHorologyLib
     public static bool IsConsistent(Race race)
     {
       HashSet<uint> startnumbers = new HashSet<uint>();
-      foreach(var rp in race.GetParticipants())
+      foreach (var rp in race.GetParticipants())
       {
         var stnr = rp.StartNumber;
         if (stnr == 0 || !startnumbers.Add(stnr))
@@ -1390,18 +1395,18 @@ namespace RaceHorologyLib
 
     public RunResult OriginalResult { get { return _original; } }
 
-    public EParticipantColor? MarkedForMeasurement 
-    { 
+    public EParticipantColor? MarkedForMeasurement
+    {
       get => _markedForMeasurement;
-      
-      set 
-      { 
+
+      set
+      {
         if (value != _markedForMeasurement)
         {
           _markedForMeasurement = value;
           NotifyPropertyChanged();
         }
-      } 
+      }
     }
 
     /// <summary>
@@ -1518,7 +1523,7 @@ namespace RaceHorologyLib
     /// <summary>
     /// True in case all participants have a valid time or a status other than NotSet or Normal
     /// </summary>
-    public bool IsComplete 
+    public bool IsComplete
     {
       get { return _isComplete; }
       private set { if (_isComplete != value) { _isComplete = value; NotifyPropertyChanged(); } }
@@ -1740,7 +1745,7 @@ namespace RaceHorologyLib
     }
     public EParticipantColor? IsMarkedForStartMeasurement(RaceParticipant participant)
     {
-      foreach(var entry in _markedParticipantForStartMeasurement)
+      foreach (var entry in _markedParticipantForStartMeasurement)
       {
         if (entry.Value == participant)
           return entry.Key;
@@ -1847,7 +1852,7 @@ namespace RaceHorologyLib
 
     public void InsertTimestamps(List<Timestamp> timestamps)
     {
-      foreach(var item in timestamps)
+      foreach (var item in timestamps)
         _timestamps.Add(item);
     }
 
@@ -1911,7 +1916,7 @@ namespace RaceHorologyLib
         return false;
 
       if (_results.FirstOrDefault(
-        r => (r.ResultCode == RunResult.EResultCode.Normal && r.Runtime != null) 
+        r => (r.ResultCode == RunResult.EResultCode.Normal && r.Runtime != null)
           || (r.ResultCode != RunResult.EResultCode.NotSet && r.ResultCode != RunResult.EResultCode.Normal)) != null)
         return true;
 
@@ -2017,11 +2022,11 @@ namespace RaceHorologyLib
         return;
 
       int idxFinishDst = 0;
-      for(int idxStart = startList.Count-1; idxStart>0; idxStart--)
+      for (int idxStart = startList.Count - 1; idxStart > 0; idxStart--)
       {
         var entryStartList = startList[idxStart];
 
-        int idxFinishSrc = idxFinishDst; 
+        int idxFinishSrc = idxFinishDst;
         while (idxFinishSrc < _inFinish.Count)
         {
           if (_inFinish[idxFinishSrc].Participant == entryStartList.Participant)

--- a/RaceHorologyLib/Import.cs
+++ b/RaceHorologyLib/Import.cs
@@ -41,8 +41,6 @@ using System.Data;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using WebSocketSharp;
 
 namespace RaceHorologyLib
@@ -51,7 +49,7 @@ namespace RaceHorologyLib
   {
 
     DataSet Data { get; }
-    
+
     List<string> Columns { get; }
   }
 
@@ -283,7 +281,7 @@ namespace RaceHorologyLib
     };
 
     public ParticipantMapping(List<string> availableFields) : base(_requiredField.Keys, availableFields)
-    { 
+    {
     }
 
     protected override List<string> synonyms(string field)
@@ -333,10 +331,12 @@ namespace RaceHorologyLib
   public class ImportResults
   {
     int _success = 0;
+    int _skip = 0;
     int _error = 0;
     List<string> _errors;
 
     public int SuccessCount { get { return _success; } }
+    public int SkipCount { get { return _skip; } }
     public int ErrorCount { get { return _error; } }
     public List<string> Errors { get { return _errors; } }
 
@@ -349,6 +349,10 @@ namespace RaceHorologyLib
     public void AddSuccess()
     {
       _success++;
+    }
+    public void AddSkip()
+    {
+      _skip++;
     }
 
     public void AddError()
@@ -379,6 +383,11 @@ namespace RaceHorologyLib
     {
       _mapping = mapping;
       _classAssignment = classAssignment;
+    }
+
+    public bool IsColumnAssigned(string field)
+    {
+      return _mapping.MappedField(field) != null;
     }
 
     public object GetValueAsObject(DataRow row, string field)
@@ -424,7 +433,7 @@ namespace RaceHorologyLib
       {
         return Convert.ToUInt32(v);
       }
-      catch(Exception)
+      catch (Exception)
       {
         return @default;
       }
@@ -516,7 +525,7 @@ namespace RaceHorologyLib
       if (!string.IsNullOrEmpty(p1.Code) && !string.IsNullOrEmpty(p2.Code))
         return p1.Code == p2.Code;
 
-      return p1.Fullname == p2.Fullname;
+      return p1.Fullname == p2.Fullname && p1.Year == p2.Year;
     }
 
 
@@ -625,25 +634,29 @@ namespace RaceHorologyLib
     IList<Participant> _particpants;
     ParticipantImportUtils _partImportUtils;
 
-    public ParticipantImport(IList<Participant> particpants, Mapping mapping, IList<ParticipantCategory> categories, ClassAssignment classAssignment = null, IList<Team> teams = null) 
+
+    public ParticipantImport(IList<Participant> particpants, Mapping mapping, IList<ParticipantCategory> categories, ClassAssignment classAssignment = null, IList<Team> teams = null)
     {
       _particpants = particpants;
       _partImportUtils = new ParticipantImportUtils(mapping, categories, classAssignment, teams);
     }
 
+    public bool OnlyUpdateExisting { get; set; } = false;
 
-    public  ImportResults DoImport(DataSet ds)
+
+    public ImportResults DoImport(DataSet ds)
     {
       ImportResults impRes = new ImportResults();
 
       var rows = ds.Tables[0].Rows;
 
-      foreach(DataRow row in rows)
+      foreach (DataRow row in rows)
       {
         try
         {
-          ImportRow(row);
-          impRes.AddSuccess();
+          var participant = ImportRow(row);
+          if (participant != null) impRes.AddSuccess();
+          else impRes.AddSkip();
         }
         catch (Exception)
         {
@@ -655,21 +668,24 @@ namespace RaceHorologyLib
     }
 
 
-    public Participant ImportRow(DataRow row) 
+    public Participant ImportRow(DataRow row)
     {
       Participant partImported = null;
 
-      Participant partCreated = _partImportUtils.CreateParticipant(row);
+      Participant partCreated = _partImportUtils.CreateParticipant(row); // Only import assigned field
 
       Participant partExisting = findExistingParticpant(partCreated);
 
       if (partExisting != null)
-        partImported = _partImportUtils.UpdateParticipant(partExisting, partCreated);
-      else
+        partImported = _partImportUtils.UpdateParticipant(partExisting, partCreated); // Only update assigned fields
+      else if (!OnlyUpdateExisting)
         partImported = insertParticpant(partCreated);
 
-      if (partImported.Class == null)
-        _partImportUtils.AssignClass(partImported);
+      if (partImported != null)
+      {
+        if (partImported.Class == null)
+          _partImportUtils.AssignClass(partImported);
+      }
 
       return partImported;
     }
@@ -700,6 +716,14 @@ namespace RaceHorologyLib
       _race = race;
       _partImportUtils = new ParticipantImportUtils(mapping, _race.GetDataModel().GetParticipantCategories(), classAssignment, teams);
       _participantImport = new ParticipantImport(_race.GetDataModel().GetParticipants(), mapping, _race.GetDataModel().GetParticipantCategories(), classAssignment, teams);
+      _participantImport.OnlyUpdateExisting = this.OnlyUpdateExisting = false;
+    }
+
+    bool _onlyUpdateExisting;
+    public bool OnlyUpdateExisting
+    {
+      get { return _onlyUpdateExisting; }
+      set { if (_onlyUpdateExisting != value) { _onlyUpdateExisting = value; _participantImport.OnlyUpdateExisting = value; } }
     }
 
 
@@ -713,7 +737,8 @@ namespace RaceHorologyLib
         try
         {
           RaceParticipant rp = ImportRow(row);
-          impRes.AddSuccess();
+          if (rp != null) impRes.AddSuccess();
+          else impRes.AddSkip();
         }
         catch (Exception)
         {
@@ -728,13 +753,15 @@ namespace RaceHorologyLib
     public RaceParticipant ImportRow(DataRow row)
     {
       Participant importedParticipant = _participantImport.ImportRow(row);
+      if (importedParticipant != null)
+      {
+        double points = _partImportUtils.GetPoints(row);
+        uint sn = _partImportUtils.GetStartNumber(row);
 
-      double points = _partImportUtils.GetPoints(row);
-      uint sn = _partImportUtils.GetStartNumber(row);
-
-      RaceParticipant rp = _race.AddParticipant(importedParticipant, sn, points);
-
-      return rp;
+        RaceParticipant rp = _race.AddParticipant(importedParticipant, sn, points);
+        return rp;
+      }
+      return null;
     }
   }
 
@@ -763,7 +790,7 @@ namespace RaceHorologyLib
       ImportResults impRes = new ImportResults();
 
       // Update the points for all participants in the race
-      foreach(var rp in _race.GetParticipants() )
+      foreach (var rp in _race.GetParticipants())
       {
         string key = string.Format("{0}_{1}", rp.Code, rp.SvId);
 

--- a/RaceHorologyLib/Import.cs
+++ b/RaceHorologyLib/Import.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (C) 2019 - 2024 by Sven Flossmann
  *  
  *  This file is part of Race Horology.
@@ -544,14 +544,14 @@ namespace RaceHorologyLib
       bool bRes = false;
       try
       {
-        bRes = p1.Name == getNameComaSeparated(GetValueAsString(row, "Name"))
-          && p1.Firstname == getFirstNameComaSeparated(GetValueAsString(row, "Firstname"))
-          && p1.Sex == importSex(GetValueAsString(row, "Sex"))
-          && p1.Club == GetValueAsString(row, "Club")
-          && p1.Nation == GetValueAsString(row, "Nation")
-          && p1.SvId == GetValueAsString(row, "SvId")
-          && p1.Code == GetValueAsString(row, "Code")
-          && p1.Year == GetValueAsUint(row, "Year");
+        bRes = (!IsColumnAssigned("Name") || p1.Name == getNameComaSeparated(GetValueAsString(row, "Name")))
+          && (!IsColumnAssigned("Firstname") || p1.Firstname == getFirstNameComaSeparated(GetValueAsString(row, "Firstname")))
+          && (!IsColumnAssigned("Sex") || p1.Sex == importSex(GetValueAsString(row, "Sex")))
+          && (!IsColumnAssigned("Club") || p1.Club == GetValueAsString(row, "Club"))
+          && (!IsColumnAssigned("Nation") || p1.Nation == GetValueAsString(row, "Nation"))
+          && (!IsColumnAssigned("SvId") || p1.SvId == GetValueAsString(row, "SvId"))
+          && (!IsColumnAssigned("Code") || p1.Code == GetValueAsString(row, "Code"))
+          && (!IsColumnAssigned("Year") || p1.Year == GetValueAsUint(row, "Year"));
       }
       catch (Exception)
       { }

--- a/RaceHorologyLib/Import.cs
+++ b/RaceHorologyLib/Import.cs
@@ -387,7 +387,8 @@ namespace RaceHorologyLib
 
     public bool IsColumnAssigned(string field)
     {
-      return _mapping.MappedField(field) != null;
+      var columnName = _mapping.MappedField(field);
+      return !(columnName == null || columnName == "---" || columnName == "");
     }
 
     public object GetValueAsObject(DataRow row, string field)
@@ -464,20 +465,27 @@ namespace RaceHorologyLib
 
     public Participant CreateParticipant(DataRow row)
     {
-      Participant p = new Participant
-      {
-        Name = getNameComaSeparated(GetValueAsString(row, "Name")),
-        Firstname = getFirstNameComaSeparated(GetValueAsString(row, "Firstname")),
-        Sex = importSex(GetValueAsString(row, "Sex")),
-        Club = GetValueAsString(row, "Club"),
-        Nation = GetValueAsString(row, "Nation"),
-        SvId = GetValueAsString(row, "SvId"),
-        Code = GetValueAsString(row, "Code"),
-        Year = GetValueAsUint(row, "Year"),
-        Class = importClass(GetValueAsString(row, "Class")),
-        Team = importTeam(GetValueAsString(row, "Team")),
-      };
-
+      Participant p = new Participant();
+      if (IsColumnAssigned("Name"))
+        p.Name = getNameComaSeparated(GetValueAsString(row, "Name"));
+      if (IsColumnAssigned("Firstname"))
+        p.Firstname = getFirstNameComaSeparated(GetValueAsString(row, "Firstname"));
+      if (IsColumnAssigned("Sex"))
+        p.Sex = importSex(GetValueAsString(row, "Sex"));
+      if (IsColumnAssigned("Club"))
+        p.Club = GetValueAsString(row, "Club");
+      if (IsColumnAssigned("Nation"))
+        p.Nation = GetValueAsString(row, "Nation");
+      if (IsColumnAssigned("SvId"))
+        p.SvId = GetValueAsString(row, "SvId");
+      if (IsColumnAssigned("Code"))
+        p.Code = GetValueAsString(row, "Code");
+      if (IsColumnAssigned("Year"))
+        p.Year = GetValueAsUint(row, "Year");
+      if (IsColumnAssigned("Class"))
+        p.Class = importClass(GetValueAsString(row, "Class"));
+      if (IsColumnAssigned("Team"))
+        p.Team = importTeam(GetValueAsString(row, "Team"));
       return p;
     }
 
@@ -525,7 +533,9 @@ namespace RaceHorologyLib
       if (!string.IsNullOrEmpty(p1.Code) && !string.IsNullOrEmpty(p2.Code))
         return p1.Code == p2.Code;
 
-      return p1.Fullname == p2.Fullname && p1.Year == p2.Year;
+      return p1.Fullname == p2.Fullname
+        && (!IsColumnAssigned("Year") || p1.Year == p2.Year)
+        && (!IsColumnAssigned("Sex") || p1.Sex == p2.Sex);
     }
 
 
@@ -558,7 +568,26 @@ namespace RaceHorologyLib
 
     public Participant UpdateParticipant(Participant partExisting, Participant partImp)
     {
-      partExisting.Assign(partImp);
+      if (IsColumnAssigned("Name"))
+        partExisting.Name = partImp.Name;
+      if (IsColumnAssigned("Firstname"))
+        partExisting.Firstname = partImp.Firstname;
+      if (IsColumnAssigned("Sex"))
+        partExisting.Sex = partImp.Sex;
+      if (IsColumnAssigned("Year"))
+        partExisting.Year = partImp.Year;
+      if (IsColumnAssigned("Club"))
+        partExisting.Club = partImp.Club;
+      if (IsColumnAssigned("SvId"))
+        partExisting.SvId = partImp.SvId;
+      if (IsColumnAssigned("Code"))
+        partExisting.Code = partImp.Code;
+      if (IsColumnAssigned("Nation"))
+        partExisting.Nation = partImp.Nation;
+      if (IsColumnAssigned("Class"))
+        partExisting.Class = partImp.Class;
+      if (IsColumnAssigned("Team"))
+        partExisting.Team = partImp.Team;
       return partExisting;
     }
 
@@ -619,13 +648,6 @@ namespace RaceHorologyLib
 
 
   }
-
-
-
-
-
-
-
 
 
 

--- a/RaceHorologyLib/Import.cs
+++ b/RaceHorologyLib/Import.cs
@@ -560,12 +560,6 @@ namespace RaceHorologyLib
     }
 
 
-    public bool EqualsParticipant(Participant p1, Participant p2)
-    {
-      return p1.IsEqualTo(p2);
-    }
-
-
     public Participant UpdateParticipant(Participant partExisting, Participant partImp)
     {
       if (IsColumnAssigned("Name"))


### PR DESCRIPTION
Um e.g. nur Punkte aus einer Gesamtwertung zu importieren, kann man jetzt ein aktualisierenden Import durchführen.
Hierbei werden nur bereits im Bewerb vorhandene Teilnehmer aktualisiert und keine neuen Teilnehmer hinzugefügt.
Weiterhin werden bei einem Import nur noch die Felder importiert, die auch wirklich selektiert worden sind. Bisher wurden bei nicht selektierten Feldern Standardwerte (meist "") importiert.