### PR TITLE
Feature FISExport

### DIFF
--- a/RaceHorology/ExportUI.cs
+++ b/RaceHorology/ExportUI.cs
@@ -87,44 +87,44 @@ namespace RaceHorology
       return null;
     }
 
-    //public static string ExportFis(Race race)
-    //{
-    //  string filePath = System.IO.Path.Combine(
-    //    race.GetDataModel().GetDB().GetDBPathDirectory(),
-    //    System.IO.Path.GetFileNameWithoutExtension(race.GetDataModel().GetDB().GetDBFileName()) + ".zip");
+    public static string ExportFis(Race race)
+    {
+      string filePath = System.IO.Path.Combine(
+        race.GetDataModel().GetDB().GetDBPathDirectory(),
+        System.IO.Path.GetFileNameWithoutExtension(race.GetDataModel().GetDB().GetDBFileName()) + ".zip");
 
-    //  Microsoft.Win32.SaveFileDialog openFileDialog = new Microsoft.Win32.SaveFileDialog();
-    //  openFileDialog.FileName = System.IO.Path.GetFileName(filePath);
-    //  openFileDialog.InitialDirectory = System.IO.Path.GetDirectoryName(filePath);
-    //  openFileDialog.DefaultExt = ".zip";
-    //  openFileDialog.Filter = "FIS Results (.zip)|*.zip";
-    //  try
-    //  {
-    //    if (openFileDialog.ShowDialog() == true)
-    //    {
-    //      filePath = openFileDialog.FileName;
-    //      FISExport fisExport = new FISExport();
-    //      fisExport.Export(filePath, race);
+      Microsoft.Win32.SaveFileDialog openFileDialog = new Microsoft.Win32.SaveFileDialog();
+      openFileDialog.FileName = System.IO.Path.GetFileName(filePath);
+      openFileDialog.InitialDirectory = System.IO.Path.GetDirectoryName(filePath);
+      openFileDialog.DefaultExt = ".zip";
+      openFileDialog.Filter = "FIS Results (.zip)|*.zip";
+      try
+      {
+        if (openFileDialog.ShowDialog() == true)
+        {
+          filePath = openFileDialog.FileName;
+          FISExport fisExport = new FISExport();
+          fisExport.Export(filePath, race);
 
-    //      return filePath;
-    //    }
-    //  }
-    //  catch (FISExportException ex)
-    //  {
-    //    System.Windows.MessageBox.Show(
-    //      "Datei " + System.IO.Path.GetFileName(filePath) + " konnte nicht gespeichert werden.\n\nFehlermeldung: " + ex.GetHumanReadableError(),
-    //      "Fehler",
-    //      System.Windows.MessageBoxButton.OK, MessageBoxImage.Exclamation);
-    //  }
-    //  catch (Exception ex)
-    //  {
-    //    System.Windows.MessageBox.Show(
-    //      "Datei " + System.IO.Path.GetFileName(filePath) + " konnte nicht gespeichert werden.\n\n" + ex.Message,
-    //      "Fehler",
-    //      System.Windows.MessageBoxButton.OK, MessageBoxImage.Exclamation);
-    //  }
-    //  return null;
-    //}
+          return filePath;
+        }
+      }
+      catch (FISExportException ex)
+      {
+        System.Windows.MessageBox.Show(
+          "Datei " + System.IO.Path.GetFileName(filePath) + " konnte nicht gespeichert werden.\n\nFehlermeldung: " + ex.GetHumanReadableError(),
+          "Fehler",
+          System.Windows.MessageBoxButton.OK, MessageBoxImage.Exclamation);
+      }
+      catch (Exception ex)
+      {
+        System.Windows.MessageBox.Show(
+          "Datei " + System.IO.Path.GetFileName(filePath) + " konnte nicht gespeichert werden.\n\n" + ex.Message,
+          "Fehler",
+          System.Windows.MessageBoxButton.OK, MessageBoxImage.Exclamation);
+      }
+      return null;
+    }
 
     public static string ExportRaceEngine(Race race)
     {

--- a/RaceHorology/MainWindow.xaml.cs
+++ b/RaceHorology/MainWindow.xaml.cs
@@ -719,6 +719,7 @@ namespace RaceHorology
     {
       List<ExportConfig> exportConfigs = new List<ExportConfig> {
         { new ExportConfig { Name = "DSV (XML Format)", ExportFunc = ExportUI.ExportDsv } },
+        { new ExportConfig { Name = "FIS (XML Format)", ExportFunc = ExportUI.ExportFis } },
         { new ExportConfig { Name = "RaceEngine (ZIP Format)", ExportFunc = ExportUI.ExportRaceEngine } },
         { new ExportConfig { Name = "rennmeldung.de", ExportFunc = ExportUI.ExportDsvAlpin } },
         { new ExportConfig { Name = "Excel", ExportFunc = ExportUI.ExportXLSX } },

--- a/RaceHorology/RaceUC.xaml
+++ b/RaceHorology/RaceUC.xaml
@@ -64,8 +64,11 @@
               <RowDefinition Height="Auto" />
               <RowDefinition Height="Auto" />
               <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto"/>
-              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto" />
+              <RowDefinition Height="Auto" />
+              <RowDefinition Height="Auto" />
+              <RowDefinition Height="Auto" />
+              <RowDefinition Height="Auto" />
               <RowDefinition Height="Auto" />
               <RowDefinition Height="Auto" />
               <RowDefinition Height="Auto" />
@@ -104,11 +107,14 @@
             <Label x:Name="lblLocation" Margin="5,0,0,0" Content="Ort:" Grid.Row="2" Grid.Column="0"/>
             <TextBox x:Name="txtLocation" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding Location}"/>
 
-            <Label x:Name="lblCorseName" Margin="5,0,0,0" Content="Strecke:" Grid.Row="3" Grid.Column="0"/>
-            <TextBox x:Name="txtCoarseName" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding CoarseName}"/>
+            <Label x:Name="lblRaceNation" Margin="5,0,0,0" Content="Nation:" Grid.Row="3" Grid.Column="0"/>
+            <TextBox x:Name="txtRaceNation" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding RaceNation}"/>
 
-            <Label x:Name="lblDate" VerticalAlignment="Center" Margin="5,0,0,0" Content="Datum:" Grid.Row="4" Grid.Column="0"/>
-            <Grid Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" >
+            <Label x:Name="lblCorseName" Margin="5,0,0,0" Content="Strecke:" Grid.Row="4" Grid.Column="0"/>
+            <TextBox x:Name="txtCoarseName" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding CoarseName}"/>
+
+            <Label x:Name="lblDate" VerticalAlignment="Center" Margin="5,0,0,0" Content="Datum:" Grid.Row="5" Grid.Column="0"/>
+            <Grid Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" >
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
@@ -121,33 +127,40 @@
               <DatePicker Margin="5" VerticalAlignment="Center" Grid.Column="3" SelectedDate="{Binding DateResultList, Mode=TwoWay}"/>
             </Grid>
 
-            <Label x:Name="lblDescription" Margin="5,0,0,0" Content="Beschreibung:" Grid.Row="5" Grid.Column="0"/>
-            <TextBox x:Name="txtDescription" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" AcceptsReturn="True" Height="50" Text="{Binding Description}"/>
+            <Label x:Name="lblDescription" Margin="5,0,0,0" Content="Beschreibung:" Grid.Row="6" Grid.Column="0"/>
+            <TextBox x:Name="txtDescription" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" AcceptsReturn="True" Height="50" Text="{Binding Description}"/>
 
-            <Label x:Name="lblOrganisator" Margin="5,0,0,0" Content="Organisator:" Grid.Row="6" Grid.Column="0"/>
-            <TextBox x:Name="txtOrganisator" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding Organizer}"/>
+            <Label x:Name="lblFISCategory" Margin="5,0,0,0" Content="FIS-Kategorie:" Grid.Row="7" Grid.Column="0"/>
+            <TextBox x:Name="txtFISCategory" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding FISCategory}"/>
 
-            <Label x:Name="lblAnalyzer" Margin="5,0,0,0" Content="Auswertung / Zeitnahme:" Grid.Row="7" Grid.Column="0"/>
-            <TextBox x:Name="txtAnalyzer" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="7" Grid.Column="1" Text="{Binding Path=Analyzer.Name}"/>
-            <TextBox x:Name="txtAnalyzerClub" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="7" Grid.Column="2" Text="{Binding Path=Analyzer.Club}"/>
+            <Label x:Name="lblOrganisator" Margin="5,0,0,0" Content="Organisator:" Grid.Row="8" Grid.Column="0"/>
+            <TextBox x:Name="txtOrganisator" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding Organizer}"/>
 
-            <Label x:Name="lblRaceDirector" Margin="5,0,0,0" Content="Schiedsrichter:" Grid.Row="8" Grid.Column="0" />
-            <TextBox x:Name="txtRaceDirector" Margin="5" HorizontalAlignment="Stretch" Grid.Row="8" Grid.Column="1" Text="{Binding Path=RaceReferee.Name}"/>
-            <TextBox x:Name="txtRaceDirectorClub" Margin="5" HorizontalAlignment="Stretch" Grid.Row="8" Grid.Column="2"  Text="{Binding Path=RaceReferee.Club}"/>
+            <Label x:Name="lblAnalyzer" Margin="5,0,0,0" Content="Auswertung / Zeitnahme:" Grid.Row="9" Grid.Column="0"/>
+            <TextBox x:Name="txtAnalyzer" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="9" Grid.Column="1" Text="{Binding Path=Analyzer.Name}"/>
+            <TextBox x:Name="txtAnalyzerClub" Margin="5" HorizontalAlignment="Stretch"  Grid.Row="9" Grid.Column="2" Text="{Binding Path=Analyzer.Club}"/>
 
-            <Label x:Name="lblRaceManager" Margin="5,0,0,0" Content="Rennleiter:" Grid.Row="9" Grid.Column="0"/>
-            <TextBox x:Name="txtRaceManager" Margin="5" HorizontalAlignment="Stretch" Grid.Row="9" Grid.Column="1" Text="{Binding Path=RaceManager.Name}"/>
-            <TextBox x:Name="txtRaceManagerClub" Margin="5" HorizontalAlignment="Stretch" Grid.Row="9" Grid.Column="2" Text="{Binding Path=RaceManager.Club}"/>
+            <Label x:Name="lblRaceDirector" Margin="5,0,0,0" Content="Schiedsrichter:" Grid.Row="10" Grid.Column="0" />
+            <TextBox x:Name="txtRaceDirector" Margin="5" HorizontalAlignment="Stretch" Grid.Row="10" Grid.Column="1" Text="{Binding Path=RaceReferee.Name}"/>
+            <TextBox x:Name="txtRaceDirectorClub" Margin="5" HorizontalAlignment="Stretch" Grid.Row="10" Grid.Column="2"  Text="{Binding Path=RaceReferee.Club}"/>
 
-            <Label x:Name="lblTrainerRepresentative" Margin="5,0,0,0" Content="Trainervertreter:" Grid.Row="10" Grid.Column="0"/>
-            <TextBox x:Name="txtTrainerRepresentative" Margin="5" HorizontalAlignment="Stretch" Grid.Row="10" Grid.Column="1" Text="{Binding Path=TrainerRepresentative.Name}"/>
-            <TextBox x:Name="txtTrainerRepresentativeClub" Margin="5" HorizontalAlignment="Stretch" Grid.Row="10" Grid.Column="2" Text="{Binding Path=TrainerRepresentative.Club}"/>
+            <Label x:Name="lblRaceManager" Margin="5,0,0,0" Content="Rennleiter:" Grid.Row="11" Grid.Column="0"/>
+            <TextBox x:Name="txtRaceManager" Margin="5" HorizontalAlignment="Stretch" Grid.Row="11" Grid.Column="1" Text="{Binding Path=RaceManager.Name}"/>
+            <TextBox x:Name="txtRaceManagerClub" Margin="5" HorizontalAlignment="Stretch" Grid.Row="11" Grid.Column="2" Text="{Binding Path=RaceManager.Club}"/>
 
-            <DockPanel Height="25" Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,15,0,0">
+            <Label x:Name="lblTrainerRepresentative" Margin="5,0,0,0" Content="Trainervertreter/TD:" Grid.Row="12" Grid.Column="0"/>
+            <TextBox x:Name="txtTrainerRepresentative" Margin="5" HorizontalAlignment="Stretch" Grid.Row="12" Grid.Column="1" Text="{Binding Path=TrainerRepresentative.Name}"/>
+            <TextBox x:Name="txtTrainerRepresentativeClub" Margin="5" HorizontalAlignment="Stretch" Grid.Row="12" Grid.Column="2" Text="{Binding Path=TrainerRepresentative.Club}"/>
+
+            <Label x:Name="lblAssistantReferee" Margin="5,0,0,0" Content="Schiedsrichterassistent (nur FIS):" Grid.Row="13" Grid.Column="0"/>
+            <TextBox x:Name="txtAssistantReferee" Margin="5" HorizontalAlignment="Stretch" Grid.Row="13" Grid.Column="1" Text="{Binding Path=AssistantReferee.Name}"/>
+            <TextBox x:Name="txtAssistantRefereeClub" Margin="5" HorizontalAlignment="Stretch" Grid.Row="13" Grid.Column="2" Text="{Binding Path=AssistantReferee.Club}"/>
+
+            <DockPanel Height="25" Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,15,0,0">
               <Label DockPanel.Dock="Left" Content="Streckendaten"/>
               <Separator/>
             </DockPanel>
-            <Grid Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="3" Margin="5,0,0,0">
+            <Grid Grid.Row="15" Grid.Column="0" Grid.ColumnSpan="3" Margin="5,0,0,0">
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
                 <ColumnDefinition Width="*"/>
@@ -176,28 +189,28 @@
 
             </Grid>
 
-            <DockPanel Height="25" Grid.Row="15" Grid.ColumnSpan="3" Margin="0,15,0,0">
+            <DockPanel Height="25" Grid.Row="18" Grid.ColumnSpan="3" Margin="0,15,0,0">
               <Label DockPanel.Dock="Left" Content="Durchgang 1"/>
               <Separator/>
             </DockPanel>
 
-            <Label x:Name="lblCourseSetter1" Margin="5,0,0,0" Content="Kurssetzer:" Grid.Row="16" Grid.Column="0"/>
-            <TextBox x:Name="txtCourseSetter1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="16" Grid.Column="1" Text="{Binding Path=RaceRun1.CoarseSetter.Name}"/>
-            <TextBox x:Name="txtCourseSetterClub1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="16" Grid.Column="2" Text="{Binding Path=RaceRun1.CoarseSetter.Club}"/>
+            <Label x:Name="lblCourseSetter1" Margin="5,0,0,0" Content="Kurssetzer:" Grid.Row="19" Grid.Column="0"/>
+            <TextBox x:Name="txtCourseSetter1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="19" Grid.Column="1" Text="{Binding Path=RaceRun1.CoarseSetter.Name}"/>
+            <TextBox x:Name="txtCourseSetterClub1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="19" Grid.Column="2" Text="{Binding Path=RaceRun1.CoarseSetter.Club}"/>
 
-            <Label x:Name="lblForeRunner1_1" Margin="5,0,0,0" Content="Vorläufer 1:" Grid.Row="17" Grid.Column="0"/>
-            <TextBox x:Name="txtForeRunner1_1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="17" Grid.Column="1" Text="{Binding Path=RaceRun1.Forerunner1.Name}"/>
-            <TextBox x:Name="txtForeRunnerClub1_1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="17" Grid.Column="2" Text="{Binding Path=RaceRun1.Forerunner1.Club}"/>
+            <Label x:Name="lblForeRunner1_1" Margin="5,0,0,0" Content="Vorläufer 1:" Grid.Row="20" Grid.Column="0"/>
+            <TextBox x:Name="txtForeRunner1_1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="20" Grid.Column="1" Text="{Binding Path=RaceRun1.Forerunner1.Name}"/>
+            <TextBox x:Name="txtForeRunnerClub1_1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="20" Grid.Column="2" Text="{Binding Path=RaceRun1.Forerunner1.Club}"/>
 
-            <Label x:Name="lblForeRunner1_2" Margin="5,0,0,0" Content="Vorläufer 2:" Grid.Row="18" Grid.Column="0"/>
-            <TextBox x:Name="txtForeRunner1_2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="18" Grid.Column="1" Text="{Binding Path=RaceRun1.Forerunner2.Name}"/>
-            <TextBox x:Name="txtForeRunnerClub1_2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="18" Grid.Column="2" Text="{Binding Path=RaceRun1.Forerunner2.Club}"/>
+            <Label x:Name="lblForeRunner1_2" Margin="5,0,0,0" Content="Vorläufer 2:" Grid.Row="21" Grid.Column="0"/>
+            <TextBox x:Name="txtForeRunner1_2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="21" Grid.Column="1" Text="{Binding Path=RaceRun1.Forerunner2.Name}"/>
+            <TextBox x:Name="txtForeRunnerClub1_2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="21" Grid.Column="2" Text="{Binding Path=RaceRun1.Forerunner2.Club}"/>
 
-            <Label x:Name="lblForeRunner1_3" Margin="5,0,0,0" Content="Vorläufer 3:" Grid.Row="19" Grid.Column="0"/>
-            <TextBox x:Name="txtForeRunner1_3" Margin="5" HorizontalAlignment="Stretch" Grid.Row="19" Grid.Column="1" Text="{Binding Path=RaceRun1.Forerunner3.Name}"/>
-            <TextBox x:Name="txtForeRunnerClub1_3" Margin="5" HorizontalAlignment="Stretch" Grid.Row="19" Grid.Column="2" Text="{Binding Path=RaceRun1.Forerunner3.Club}"/>
+            <Label x:Name="lblForeRunner1_3" Margin="5,0,0,0" Content="Vorläufer 3:" Grid.Row="22" Grid.Column="0"/>
+            <TextBox x:Name="txtForeRunner1_3" Margin="5" HorizontalAlignment="Stretch" Grid.Row="22" Grid.Column="1" Text="{Binding Path=RaceRun1.Forerunner3.Name}"/>
+            <TextBox x:Name="txtForeRunnerClub1_3" Margin="5" HorizontalAlignment="Stretch" Grid.Row="22" Grid.Column="2" Text="{Binding Path=RaceRun1.Forerunner3.Club}"/>
 
-            <Grid Grid.Row="20" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,0">
+            <Grid Grid.Row="23" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,0">
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
@@ -222,28 +235,28 @@
             </Grid>
 
 
-            <DockPanel Height="25" Grid.Row="21" Grid.ColumnSpan="3" Margin="0,15,0,0">
+            <DockPanel Height="25" Grid.Row="24" Grid.ColumnSpan="3" Margin="0,15,0,0">
               <Label DockPanel.Dock="Left" Content="Durchgang 2"/>
               <Separator/>
             </DockPanel>
 
-            <Label x:Name="lblCourseSetter2" Margin="5,0,0,0" Content="Kurssetzer:" Grid.Row="22" Grid.Column="0"/>
-            <TextBox x:Name="txtCourseSetter2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="22" Grid.Column="1" Text="{Binding Path=RaceRun2.CoarseSetter.Name}"/>
-            <TextBox x:Name="txtCourseSetterClub2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="22" Grid.Column="2" Text="{Binding Path=RaceRun2.CoarseSetter.Club}"/>
+            <Label x:Name="lblCourseSetter2" Margin="5,0,0,0" Content="Kurssetzer:" Grid.Row="25" Grid.Column="0"/>
+            <TextBox x:Name="txtCourseSetter2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="25" Grid.Column="1" Text="{Binding Path=RaceRun2.CoarseSetter.Name}"/>
+            <TextBox x:Name="txtCourseSetterClub2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="25" Grid.Column="2" Text="{Binding Path=RaceRun2.CoarseSetter.Club}"/>
 
-            <Label x:Name="lblForeRunner2_1" Margin="5,0,0,0" Content="Vorläufer 1:" Grid.Row="23" Grid.Column="0"/>
-            <TextBox x:Name="txtForeRunner2_1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="23" Grid.Column="1" Text="{Binding Path=RaceRun2.Forerunner1.Name}"/>
-            <TextBox x:Name="txtForeRunnerClub2_1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="23" Grid.Column="2" Text="{Binding Path=RaceRun2.Forerunner1.Club}"/>
+            <Label x:Name="lblForeRunner2_1" Margin="5,0,0,0" Content="Vorläufer 1:" Grid.Row="26" Grid.Column="0"/>
+            <TextBox x:Name="txtForeRunner2_1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="26" Grid.Column="1" Text="{Binding Path=RaceRun2.Forerunner1.Name}"/>
+            <TextBox x:Name="txtForeRunnerClub2_1" Margin="5" HorizontalAlignment="Stretch" Grid.Row="26" Grid.Column="2" Text="{Binding Path=RaceRun2.Forerunner1.Club}"/>
 
-            <Label x:Name="lblForeRunner2_2" Margin="5,0,0,0" Content="Vorläufer 2:" Grid.Row="24" Grid.Column="0"/>
-            <TextBox x:Name="txtForeRunner2_2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="24" Grid.Column="1" Text="{Binding Path=RaceRun2.Forerunner2.Name}"/>
-            <TextBox x:Name="txtForeRunnerClub2_2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="24" Grid.Column="2" Text="{Binding Path=RaceRun2.Forerunner2.Club}"/>
+            <Label x:Name="lblForeRunner2_2" Margin="5,0,0,0" Content="Vorläufer 2:" Grid.Row="27" Grid.Column="0"/>
+            <TextBox x:Name="txtForeRunner2_2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="27" Grid.Column="1" Text="{Binding Path=RaceRun2.Forerunner2.Name}"/>
+            <TextBox x:Name="txtForeRunnerClub2_2" Margin="5" HorizontalAlignment="Stretch" Grid.Row="27" Grid.Column="2" Text="{Binding Path=RaceRun2.Forerunner2.Club}"/>
 
-            <Label x:Name="lblForeRunner2_3" Margin="5,0,0,0" Content="Vorläufer 3:" Grid.Row="25" Grid.Column="0"/>
-            <TextBox x:Name="txtForeRunner2_3" Margin="5" HorizontalAlignment="Stretch" Grid.Row="25" Grid.Column="1" Text="{Binding Path=RaceRun2.Forerunner3.Name}"/>
-            <TextBox x:Name="txtForeRunnerClub2_3" Margin="5" HorizontalAlignment="Stretch" Grid.Row="25" Grid.Column="2" Text="{Binding Path=RaceRun2.Forerunner3.Club}"/>
+            <Label x:Name="lblForeRunner2_3" Margin="5,0,0,0" Content="Vorläufer 3:" Grid.Row="28" Grid.Column="0"/>
+            <TextBox x:Name="txtForeRunner2_3" Margin="5" HorizontalAlignment="Stretch" Grid.Row="28" Grid.Column="1" Text="{Binding Path=RaceRun2.Forerunner3.Name}"/>
+            <TextBox x:Name="txtForeRunnerClub2_3" Margin="5" HorizontalAlignment="Stretch" Grid.Row="28" Grid.Column="2" Text="{Binding Path=RaceRun2.Forerunner3.Club}"/>
 
-            <Grid Grid.Row="26" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,0">
+            <Grid Grid.Row="29" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,0">
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
@@ -267,11 +280,11 @@
               <TextBox Margin="5"  Grid.Row="0" Grid.Column="6" Text="{Binding Path=RaceRun2.StartTime}" Width="60"/>
             </Grid>
 
-            <DockPanel Height="25" Grid.Row="27" Grid.ColumnSpan="3" Margin="0,15,0,0">
+            <DockPanel Height="25" Grid.Row="30" Grid.ColumnSpan="3" Margin="0,15,0,0">
               <Label DockPanel.Dock="Left" Content="Wetterdaten"/>
               <Separator/>
             </DockPanel>
-            <Grid Grid.Row="28" Grid.Column="0" Grid.ColumnSpan="3" Margin="5,0,0,0">
+            <Grid Grid.Row="31" Grid.Column="0" Grid.ColumnSpan="3" Margin="5,0,0,0">
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
                 <ColumnDefinition Width="*"/>
@@ -296,12 +309,12 @@
               <TextBox Margin="5"  Grid.Row="1" Grid.Column="3" Text="{Binding Path=TempFinish}"/>
             </Grid>
 
-            <Grid Grid.Row="29" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,15,5,0" >
+            <Grid Grid.Row="32" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,15,5,0" >
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
-              
+
               <local:SaveOrResetUC x:Name="ucPropSaveOrReset"  />
               <Button x:Name="btnLoadProp" Grid.Column="2" Padding="5" HorizontalAlignment="Right" Content="Importieren aus anderem Rennen" Click="btnLoadProp_Click"/>
             </Grid>

--- a/RaceHorology/RaceUC.xaml
+++ b/RaceHorology/RaceUC.xaml
@@ -150,7 +150,16 @@
 
             <Label x:Name="lblTrainerRepresentative" Margin="5,0,0,0" Content="Trainervertreter/TD:" Grid.Row="12" Grid.Column="0"/>
             <TextBox x:Name="txtTrainerRepresentative" Margin="5" HorizontalAlignment="Stretch" Grid.Row="12" Grid.Column="1" Text="{Binding Path=TrainerRepresentative.Name}"/>
-            <TextBox x:Name="txtTrainerRepresentativeClub" Margin="5" HorizontalAlignment="Stretch" Grid.Row="12" Grid.Column="2" Text="{Binding Path=TrainerRepresentative.Club}"/>
+            <Grid Grid.Row="12" Grid.Column="2">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="80" />
+              </Grid.ColumnDefinitions>
+              <TextBox x:Name="txtTrainerRepresentativeClub" Margin="5" HorizontalAlignment="Stretch" Grid.Column="0" Text="{Binding Path=TrainerRepresentative.Club}"/>
+              <Label Content="TD-Nummer:" Grid.Column="1" Margin="5,0,0,0"/>
+              <TextBox x:Name="txtTDNumber" Margin="5" HorizontalAlignment="Stretch" Grid.Column="2" Text="{Binding TDNumber}"/>
+            </Grid>
 
             <Label x:Name="lblAssistantReferee" Margin="5,0,0,0" Content="Schiedsrichterassistent (nur FIS):" Grid.Row="13" Grid.Column="0"/>
             <TextBox x:Name="txtAssistantReferee" Margin="5" HorizontalAlignment="Stretch" Grid.Row="13" Grid.Column="1" Text="{Binding Path=AssistantReferee.Name}"/>

--- a/RaceHorologyLib/AppDataModel.cs
+++ b/RaceHorologyLib/AppDataModel.cs
@@ -688,7 +688,11 @@ namespace RaceHorologyLib
     public string Organizer { get; set; }
     public Person RaceReferee { get; set; } = new Person(); // Schiedsrichter
     public Person RaceManager { get; set; } = new Person(); // Rennleiter
-    public Person TrainerRepresentative { get; set; } = new Person(); // Trainer Vertreter
+    public Person TrainerRepresentative { get; set; } = new Person(); // Trainer Vertreter / TD
+    public Person AssistantReferee { get; set; } = new Person(); // Schiedsrichterassistent (FIS only)
+
+    public string RaceNation { get; set; }
+    public string FISCategory { get; set; }
 
     public string CoarseName { get; set; }
     public int CoarseLength { get; set; } // m
@@ -718,6 +722,9 @@ namespace RaceHorologyLib
         && Person.Equals(p1?.RaceReferee, p2?.RaceReferee)
         && Person.Equals(p1?.RaceManager, p2?.RaceManager)
         && Person.Equals(p1?.TrainerRepresentative, p2?.TrainerRepresentative)
+        && Person.Equals(p1?.AssistantReferee, p2?.AssistantReferee)
+        && string.Equals(p1?.RaceNation, p2?.RaceNation)
+        && string.Equals(p1?.FISCategory, p2?.FISCategory)
         && string.Equals(p1?.CoarseName, p2?.CoarseName)
         && p1?.CoarseLength == p2?.CoarseLength
         && string.Equals(p1?.CoarseHomologNo, p2?.CoarseHomologNo)

--- a/RaceHorologyLib/AppDataModel.cs
+++ b/RaceHorologyLib/AppDataModel.cs
@@ -689,6 +689,7 @@ namespace RaceHorologyLib
     public Person RaceReferee { get; set; } = new Person(); // Schiedsrichter
     public Person RaceManager { get; set; } = new Person(); // Rennleiter
     public Person TrainerRepresentative { get; set; } = new Person(); // Trainer Vertreter / TD
+    public string TDNumber { get; set; }
     public Person AssistantReferee { get; set; } = new Person(); // Schiedsrichterassistent (FIS only)
 
     public string RaceNation { get; set; }
@@ -722,6 +723,7 @@ namespace RaceHorologyLib
         && Person.Equals(p1?.RaceReferee, p2?.RaceReferee)
         && Person.Equals(p1?.RaceManager, p2?.RaceManager)
         && Person.Equals(p1?.TrainerRepresentative, p2?.TrainerRepresentative)
+        && string.Equals(p1?.TDNumber, p2?.TDNumber)
         && Person.Equals(p1?.AssistantReferee, p2?.AssistantReferee)
         && string.Equals(p1?.RaceNation, p2?.RaceNation)
         && string.Equals(p1?.FISCategory, p2?.FISCategory)

--- a/RaceHorologyLib/Database.cs
+++ b/RaceHorologyLib/Database.cs
@@ -1012,6 +1012,11 @@ namespace RaceHorologyLib
               case 45: props.TempStart = value; break;
               case 46: props.TempFinish = value; break;
 
+              case 47: props.AssistantReferee.Name = value; break;
+              case 48: props.AssistantReferee.Club = value; break;
+              case 49: props.RaceNation = value; break;
+              case 50: props.FISCategory = value; break;
+
               default:
                 break;
             }
@@ -1110,6 +1115,12 @@ namespace RaceHorologyLib
       storeRacePropertyInternal(race, 44, props.Snow);
       storeRacePropertyInternal(race, 45, props.TempStart);
       storeRacePropertyInternal(race, 46, props.TempFinish);
+
+      // FIS-specific fields
+      storeRacePropertyInternal(race, 47, props.AssistantReferee.Name);
+      storeRacePropertyInternal(race, 48, props.AssistantReferee.Club);
+      storeRacePropertyInternal(race, 49, props.RaceNation);
+      storeRacePropertyInternal(race, 50, props.FISCategory);
     }
 
 

--- a/RaceHorologyLib/Database.cs
+++ b/RaceHorologyLib/Database.cs
@@ -1016,6 +1016,7 @@ namespace RaceHorologyLib
               case 48: props.AssistantReferee.Club = value; break;
               case 49: props.RaceNation = value; break;
               case 50: props.FISCategory = value; break;
+              case 51: props.TDNumber = value; break;
 
               default:
                 break;
@@ -1121,6 +1122,7 @@ namespace RaceHorologyLib
       storeRacePropertyInternal(race, 48, props.AssistantReferee.Club);
       storeRacePropertyInternal(race, 49, props.RaceNation);
       storeRacePropertyInternal(race, 50, props.FISCategory);
+      storeRacePropertyInternal(race, 51, props.TDNumber);
     }
 
 

--- a/RaceHorologyLib/FISExport.cs
+++ b/RaceHorologyLib/FISExport.cs
@@ -74,7 +74,7 @@ namespace RaceHorologyLib
           return "Rennleiter fehlt";
         case "missing racejury Referee":
           return "Schiedsrichter fehlt";
-        case "missing racejury TD":
+        case "missing racejury TechnicalDelegate":
           return "Trainervertreter/TD fehlt";
         case "missing racejury Assistantreferee":
           return "Schiedsrichterassistent fehlt";
@@ -184,31 +184,25 @@ namespace RaceHorologyLib
     {
       _writer.WriteStartElement("Fisresults");
       writeRaceheader(race);
+      _writer.WriteStartElement("AL_race");
       writeALRaceinfo(race);
       writeRaceResults(race);
-      _writer.WriteEndElement();
+      _writer.WriteEndElement(); // AL_race
+      _writer.WriteEndElement(); // Fisresults
     }
 
 
     void writeRaceheader(Race race)
     {
       _writer.WriteStartElement("Raceheader");
-
-      if (race.DateResultList == null)
-        throw new FISExportException("missing racedate");
-      writeElement("Racedate", race.DateResultList?.ToString("yyyy-MM-dd"));
-
-      writeElement("Gender", "A");
+      _writer.WriteAttributeString("Sector", "AL");
+      _writer.WriteAttributeString("Gender", determineGender(race));
 
       writeElement("Season", race.DateResultList?.AddMonths(3).ToString("yyyy"));
 
       if (string.IsNullOrWhiteSpace(race.RaceNumber))
         throw new FISExportException("missing raceid");
-      writeElement("Raceid", race.RaceNumber);
-
-      if (string.IsNullOrWhiteSpace(race.AdditionalProperties?.Organizer))
-        throw new FISExportException("missing raceorganizer");
-      writeElement("Raceorganizer", race.AdditionalProperties?.Organizer);
+      writeElement("Codex", race.RaceNumber);
 
       if (!string.IsNullOrWhiteSpace(race.AdditionalProperties?.RaceNation))
         writeElement("Nation", race.AdditionalProperties.RaceNation);
@@ -218,27 +212,31 @@ namespace RaceHorologyLib
       if (!string.IsNullOrWhiteSpace(race.AdditionalProperties?.FISCategory))
         writeElement("Category", race.AdditionalProperties.FISCategory);
 
-      if (string.IsNullOrWhiteSpace(race.Description))
-        throw new FISExportException("missing racename");
-      writeElement("Racename", race.Description);
+      if (race.DateResultList == null)
+        throw new FISExportException("missing racedate");
+      writeRacedate(race.DateResultList.Value);
+
+      if (string.IsNullOrWhiteSpace(race.AdditionalProperties?.Organizer))
+        throw new FISExportException("missing raceorganizer");
 
       if (string.IsNullOrWhiteSpace(race.AdditionalProperties?.Location))
         throw new FISExportException("missing raceplace");
-      writeElement("Raceplace", race.AdditionalProperties?.Location);
+      writeElement("Place", race.AdditionalProperties?.Location);
 
-      writeElement("Timing", string.IsNullOrWhiteSpace(race.TimingDevice) ? "Race Horology" : race.TimingDevice);
+      if (string.IsNullOrWhiteSpace(race.Description))
+        throw new FISExportException("missing racename");
+      writeElement("Eventname", race.Description);
 
-      if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Club) && !string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Name))
-        writeElement("Dataprocessing_by", string.Format("{0}, {1}", race.AdditionalProperties?.Analyzer.Name, race.AdditionalProperties?.Analyzer.Club));
-      else if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Club))
-        writeElement("Dataprocessing_by", race.AdditionalProperties?.Analyzer.Club);
-      else if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Name))
-        writeElement("Dataprocessing_by", race.AdditionalProperties?.Analyzer.Name);
+      _writer.WriteEndElement();
+    }
 
-      string software = getSoftware();
-      if (software != null)
-        writeElement("Software", software);
 
+    void writeRacedate(DateTime date)
+    {
+      _writer.WriteStartElement("Racedate");
+      writeElement("Day", date.Day.ToString());
+      writeElement("Month", date.Month.ToString());
+      writeElement("Year", date.Year.ToString());
       _writer.WriteEndElement();
     }
 
@@ -261,6 +259,10 @@ namespace RaceHorologyLib
         }
       }
 
+      if (race.AdditionalProperties?.TrainerRepresentative == null || ((AdditionalRaceProperties.Person)race.AdditionalProperties?.TrainerRepresentative).IsEmpty())
+        throw new FISExportException("missing racejury TechnicalDelegate");
+      writeJuryTD(race.AdditionalProperties?.TrainerRepresentative, race.AdditionalProperties?.TDNumber);
+
       if (race.AdditionalProperties?.RaceManager == null || ((AdditionalRaceProperties.Person)race.AdditionalProperties?.RaceManager).IsEmpty())
         throw new FISExportException("missing racejury Chiefrace");
       writeJury("Chiefrace", race.AdditionalProperties?.RaceManager);
@@ -277,13 +279,24 @@ namespace RaceHorologyLib
       if (race.AdditionalProperties?.AssistantReferee != null && !((AdditionalRaceProperties.Person)race.AdditionalProperties?.AssistantReferee).IsEmpty())
         writeJury("Assistantreferee", race.AdditionalProperties?.AssistantReferee);
 
-      if (race.AdditionalProperties?.TrainerRepresentative == null || ((AdditionalRaceProperties.Person)race.AdditionalProperties?.TrainerRepresentative).IsEmpty())
-        throw new FISExportException("missing racejury TD");
-      writeJury("TD", race.AdditionalProperties?.TrainerRepresentative);
-
       writeRuninfo(race.GetRun(0), race.AdditionalProperties?.RaceRun1);
       if (race.GetMaxRun() > 1)
         writeRuninfo(race.GetRun(1), race.AdditionalProperties?.RaceRun2);
+
+      writeElement("Timingby", string.IsNullOrWhiteSpace(race.TimingDevice) ? "Race Horology" : race.TimingDevice);
+
+      if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Club) && !string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Name))
+        writeElement("Dataprocessingby", string.Format("{0}, {1}", race.AdditionalProperties?.Analyzer.Name, race.AdditionalProperties?.Analyzer.Club));
+      else if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Club))
+        writeElement("Dataprocessingby", race.AdditionalProperties?.Analyzer.Club);
+      else if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Name))
+        writeElement("Dataprocessingby", race.AdditionalProperties?.Analyzer.Name);
+
+      writeElement("Softwarename", "RaceHorology");
+
+      string gitHash = getGitHash();
+      if (!string.IsNullOrEmpty(gitHash))
+        writeElement("Softwareversion", gitHash);
 
       _writer.WriteEndElement();
     }
@@ -296,10 +309,27 @@ namespace RaceHorologyLib
 
       _writer.WriteStartElement("Jury");
       _writer.WriteAttributeString("Function", function);
-      writeElement("Jurylastname", lastname);
-      writeElement("Juryfirstname", firstname);
+      writeElement("Lastname", lastname);
+      writeElement("Firstname", firstname);
       if (!string.IsNullOrEmpty(person?.Club))
-        writeElement("Jurynation", person.Club);
+        writeElement("Nation", person.Club);
+      _writer.WriteEndElement();
+    }
+
+
+    void writeJuryTD(AdditionalRaceProperties.Person person, string tdNumber)
+    {
+      string lastname, firstname;
+      DSVExport.guessLastAndFirstname(person?.Name, out lastname, out firstname);
+
+      _writer.WriteStartElement("Jury");
+      _writer.WriteAttributeString("Function", "TechnicalDelegate");
+      if (!string.IsNullOrEmpty(tdNumber))
+        writeElement("Number", tdNumber);
+      writeElement("Lastname", lastname);
+      writeElement("Firstname", firstname);
+      if (!string.IsNullOrEmpty(person?.Club))
+        writeElement("Nation", person.Club);
       _writer.WriteEndElement();
     }
 
@@ -307,34 +337,36 @@ namespace RaceHorologyLib
     void writeRuninfo(RaceRun raceRun, AdditionalRaceProperties.RaceRunProperties raceRunProperties)
     {
       _writer.WriteStartElement("Runinfo");
-      _writer.WriteAttributeString("Run", raceRun.Run.ToString());
+      _writer.WriteAttributeString("no", raceRun.Run.ToString());
+
+      _writer.WriteStartElement("Course");
 
       if (string.IsNullOrEmpty(raceRun.GetRace().AdditionalProperties?.CoarseName))
         throw new FISExportException("missing coarsename");
-      writeElement("Coursename", raceRun.GetRace().AdditionalProperties?.CoarseName);
+      writeElement("Name", raceRun.GetRace().AdditionalProperties?.CoarseName);
 
       if (!string.IsNullOrEmpty(raceRun.GetRace().AdditionalProperties?.CoarseHomologNo))
-        writeElement("Homologationnumber", raceRun.GetRace().AdditionalProperties.CoarseHomologNo);
+        writeElement("Homologation", raceRun.GetRace().AdditionalProperties.CoarseHomologNo);
 
       if (raceRunProperties.Gates <= 0)
         throw new FISExportException("missing number_of_gates");
-      writeElement("Numberofgates", raceRunProperties.Gates.ToString());
+      writeElement("Gates", raceRunProperties.Gates.ToString());
 
       if (raceRunProperties.Turns <= 0)
         throw new FISExportException("missing number_of_turninggates");
-      writeElement("Numberofturninggates", raceRunProperties.Turns.ToString());
-
-      if (raceRun.GetRace().AdditionalProperties?.StartHeight <= 0)
-        throw new FISExportException("missing startaltitude");
-      writeElement("Startaltitude", raceRun.GetRace().AdditionalProperties?.StartHeight.ToString());
-
-      if (raceRun.GetRace().AdditionalProperties?.FinishHeight <= 0)
-        throw new FISExportException("missing finishaltitude");
-      writeElement("Finishaltitude", raceRun.GetRace().AdditionalProperties?.FinishHeight.ToString());
+      writeElement("Turninggates", raceRunProperties.Turns.ToString());
 
       if (raceRun.GetRace().AdditionalProperties?.CoarseLength <= 0)
         throw new FISExportException("missing courselength");
-      writeElement("Courselength", raceRun.GetRace().AdditionalProperties.CoarseLength.ToString());
+      writeElement("Length", raceRun.GetRace().AdditionalProperties.CoarseLength.ToString());
+
+      if (raceRun.GetRace().AdditionalProperties?.StartHeight <= 0)
+        throw new FISExportException("missing startaltitude");
+      writeElement("Startelev", raceRun.GetRace().AdditionalProperties?.StartHeight.ToString());
+
+      if (raceRun.GetRace().AdditionalProperties?.FinishHeight <= 0)
+        throw new FISExportException("missing finishaltitude");
+      writeElement("Finishelev", raceRun.GetRace().AdditionalProperties?.FinishHeight.ToString());
 
       writeCoursesetter(raceRunProperties.CoarseSetter);
 
@@ -347,9 +379,11 @@ namespace RaceHorologyLib
       if (!string.IsNullOrWhiteSpace(raceRunProperties.Forerunner3.Name))
         writeForerunner(3, raceRunProperties.Forerunner3);
 
+      _writer.WriteEndElement(); // Course
+
       writeElement("Starttime", raceRunProperties.StartTime);
 
-      _writer.WriteEndElement();
+      _writer.WriteEndElement(); // Runinfo
     }
 
 
@@ -422,17 +456,19 @@ namespace RaceHorologyLib
         writeElement("Bib", rri.Participant.StartNumber.ToString());
         writeCompetitor(rri.Participant);
 
+        _writer.WriteStartElement("AL_result");
         foreach (var x in rri.SubResults.OrderBy(k => k.Key))
         {
           writeElement("Timerun" + x.Key, formatTime(x.Value.Runtime));
         }
-
         writeElement("Totaltime", formatTime(rri.TotalTime));
 
         if (_writePoints && rri.Points >= 0)
           writeElement("Racepoints", rri.Points.ToString("F2", CultureInfo.InvariantCulture));
 
-        _writer.WriteEndElement();
+        _writer.WriteEndElement(); // AL_result
+
+        _writer.WriteEndElement(); // AL_ranked
       }
 
       _writer.WriteEndElement();
@@ -452,11 +488,11 @@ namespace RaceHorologyLib
         _writer.WriteStartElement("AL_notranked");
         _writer.WriteAttributeString("Status", status);
 
-        writeElement("Bib", rri.Participant.StartNumber.ToString());
-        writeCompetitor(rri.Participant);
-
         if (failedRun > 0)
           writeElement("Run", failedRun.ToString());
+
+        writeElement("Bib", rri.Participant.StartNumber.ToString());
+        writeCompetitor(rri.Participant);
 
         if (!string.IsNullOrWhiteSpace(rri.DisqualText))
           writeElement("Reason", rri.DisqualText);
@@ -477,11 +513,12 @@ namespace RaceHorologyLib
       writeElement("Lastname", participant.Name);
       writeElement("Firstname", participant.Firstname);
 
-      writeElement("Year", participant.Participant.Year.ToString());
-
       writeElement("Nation", participant.Nation);
 
-      writeElement("Club", participant.Club);
+      writeElement("Yearofbirth", participant.Participant.Year.ToString());
+
+      if (!string.IsNullOrEmpty(participant.Club))
+        writeElement("Clubname", participant.Club);
 
       _writer.WriteEndElement();
     }
@@ -497,7 +534,13 @@ namespace RaceHorologyLib
 
     static string formatTime(TimeSpan? time)
     {
-      return time?.ToString(@"mm\:ss\.ff");
+      if (time == null)
+        return "";
+
+      if (time.Value.Hours > 0 || time.Value.Minutes >= 1)
+        return time.Value.ToString(@"m\:ss\.ff");
+
+      return time.Value.ToString(@"ss\.ff");
     }
 
 
@@ -515,6 +558,31 @@ namespace RaceHorologyLib
         return "SG";
 
       throw new FISExportException("not supported racetype");
+    }
+
+
+    static string determineGender(Race race)
+    {
+      bool hasMale = false;
+      bool hasFemale = false;
+
+      foreach (var participant in race.GetParticipants())
+      {
+        if (participant.Sex == null)
+          continue;
+
+        char cat = participant.Sex.Name;
+        if (cat == 'M' || cat == 'm')
+          hasMale = true;
+        else if (cat == 'W' || cat == 'w' || cat == 'L' || cat == 'l')
+          hasFemale = true;
+      }
+
+      if (hasMale && !hasFemale)
+        return "M";
+      if (hasFemale && !hasMale)
+        return "W";
+      return "A";
     }
 
 
@@ -552,20 +620,34 @@ namespace RaceHorologyLib
     }
 
 
-    string getSoftware()
+    static string getGitHash()
     {
-      Assembly assembly = Assembly.GetEntryAssembly();
-      if (assembly == null)
-        assembly = Assembly.GetExecutingAssembly();
-
-      if (assembly != null)
+      try
       {
-        FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
-        var productName = fvi.ProductName;
-        var productVersion = fvi.ProductVersion;
-
-        return string.Format("{0} {1}", productName, productVersion);
+        var process = new Process();
+        process.StartInfo.FileName = "git";
+        process.StartInfo.Arguments = "rev-parse --short HEAD";
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.CreateNoWindow = true;
+        process.Start();
+        string hash = process.StandardOutput.ReadToEnd().Trim();
+        process.WaitForExit();
+        if (process.ExitCode == 0 && !string.IsNullOrEmpty(hash))
+          return hash;
       }
+      catch { }
+
+      try
+      {
+        Assembly assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        if (assembly != null)
+        {
+          FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+          return fvi.ProductVersion;
+        }
+      }
+      catch { }
 
       return null;
     }

--- a/RaceHorologyLib/FISExport.cs
+++ b/RaceHorologyLib/FISExport.cs
@@ -1,0 +1,573 @@
+/*
+ *  Copyright (C) 2019 - 2026 by Sven Flossmann & Co-Authors (CREDITS.TXT)
+ *
+ *  This file is part of Race Horology.
+ *
+ *  Race Horology is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  Race Horology is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with Race Horology.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Diese Datei ist Teil von Race Horology.
+ *
+ *  Race Horology ist Freie Software: Sie können es unter den Bedingungen
+ *  der GNU Affero General Public License, wie von der Free Software Foundation,
+ *  Version 3 der Lizenz oder (nach Ihrer Wahl) jeder neueren
+ *  veröffentlichten Version, weiter verteilen und/oder modifizieren.
+ *
+ *  Race Horology wird in der Hoffnung, dass es nützlich sein wird, aber
+ *  OHNE JEDE GEWÄHRLEISTUNG, bereitgestellt; sogar ohne die implizite
+ *  Gewährleistung der MARKTFÄHIGKEIT oder EIGNUNG FÜR EINEN BESTIMMTEN ZWECK.
+ *  Siehe die GNU Affero General Public License für weitere Details.
+ *
+ *  Sie sollten eine Kopie der GNU Affero General Public License zusammen mit diesem
+ *  Programm erhalten haben. Wenn nicht, siehe <https://www.gnu.org/licenses/>.
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Xml;
+
+namespace RaceHorologyLib
+{
+
+  public class FISExportException : Exception
+  {
+    public FISExportException(string message) : base(message)
+    { }
+
+    public string GetHumanReadableError()
+    {
+      switch (Message)
+      {
+        case "missing racedate":
+          return "Renndatum fehlt";
+        case "missing raceid":
+          return "Rennnummer fehlt";
+        case "missing raceorganizer":
+          return "Rennorganisator fehlt";
+        case "missing racename":
+          return "Rennname und/oder Beschreibung fehlt";
+        case "missing raceplace":
+          return "Rennort fehlt";
+        case "not supported racetype":
+          return "Renntyp nicht unterstützt";
+        case "missing racejury Chiefrace":
+          return "Rennleiter fehlt";
+        case "missing racejury Referee":
+          return "Schiedsrichter fehlt";
+        case "missing racejury TD":
+          return "Trainervertreter/TD fehlt";
+        case "missing racejury Assistantreferee":
+          return "Schiedsrichterassistent fehlt";
+        case "missing coursesetter":
+          return "Kurssetzer fehlt";
+        case "missing coarsename":
+          return "Kursname fehlt";
+        case "missing number_of_gates":
+          return "Anzahl der Tore fehlt";
+        case "missing number_of_turninggates":
+          return "Anzahl der Richtungsänderungen fehlt";
+        case "missing startaltitude":
+          return "Starthöhe fehlt";
+        case "missing finishaltitude":
+          return "Zielhöhe fehlt";
+        case "missing courselength":
+          return "Kurslänge fehlt";
+        case "missing forerunner":
+          return "Vorläufer fehlt";
+        case "missing f-value":
+          return "F-Wert nicht korrekt";
+        default:
+          return Message;
+      }
+    }
+  }
+
+
+  public class FISExport
+  {
+    protected XmlWriterSettings _xmlSettings;
+    protected XmlWriter _writer;
+    protected bool _writePoints;
+
+    public FISExport()
+    {
+      _xmlSettings = new XmlWriterSettings();
+      _xmlSettings.Indent = true;
+      _xmlSettings.IndentChars = "  ";
+      _xmlSettings.Encoding = Encoding.UTF8;
+    }
+
+
+    public void Export(string pathZIPFile, Race race)
+    {
+      void addImageToZip(ZipArchive archive, string imageSrcName, string imageName, Race raceInternal)
+      {
+        PDFHelper pdfHelper = new PDFHelper(raceInternal.GetDataModel());
+        string imgSrcPath = pdfHelper.FindImage(imageSrcName);
+        if (imgSrcPath != null)
+        {
+          var imgZipFile = archive.CreateEntry(imageName + ".jpg");
+          using (var imgZipStream = imgZipFile.Open())
+          {
+            Image img = Image.FromFile(imgSrcPath);
+            img.Save(imgZipStream, ImageFormat.Jpeg);
+            imgZipStream.Close();
+          }
+        }
+      }
+
+      string baseFileName = Path.GetFileNameWithoutExtension(pathZIPFile);
+
+      using (var zipStream = new MemoryStream())
+      {
+        using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, true))
+        {
+          var xmlFile = archive.CreateEntry(baseFileName + ".xml");
+          using (var xmlStream = xmlFile.Open())
+          {
+            ExportXML(xmlStream, race);
+          }
+
+          addImageToZip(archive, "Logo1", "LogoClub", race);
+        }
+
+        using (var fileStream = new FileStream(pathZIPFile, FileMode.Create))
+        {
+          zipStream.Seek(0, SeekOrigin.Begin);
+          zipStream.CopyTo(fileStream);
+        }
+      }
+    }
+
+    public void ExportXML(string pathXMLFile, Race race)
+    {
+      FileStream output = new FileStream(pathXMLFile, FileMode.Create);
+      ExportXML(output, race);
+    }
+
+
+    public void ExportXML(Stream output, Race race)
+    {
+      _writePoints = race.RaceConfiguration.ActiveFields.Contains("Points");
+
+      _writer = XmlWriter.Create(output, _xmlSettings);
+
+      _writer.WriteStartDocument();
+      writeRace(race);
+      _writer.WriteEndDocument();
+
+      _writer.Close();
+    }
+
+
+    void writeRace(Race race)
+    {
+      _writer.WriteStartElement("Fisresults");
+      writeRaceheader(race);
+      writeALRaceinfo(race);
+      writeRaceResults(race);
+      _writer.WriteEndElement();
+    }
+
+
+    void writeRaceheader(Race race)
+    {
+      _writer.WriteStartElement("Raceheader");
+
+      if (race.DateResultList == null)
+        throw new FISExportException("missing racedate");
+      writeElement("Racedate", race.DateResultList?.ToString("yyyy-MM-dd"));
+
+      writeElement("Gender", "A");
+
+      writeElement("Season", race.DateResultList?.AddMonths(3).ToString("yyyy"));
+
+      if (string.IsNullOrWhiteSpace(race.RaceNumber))
+        throw new FISExportException("missing raceid");
+      writeElement("Raceid", race.RaceNumber);
+
+      if (string.IsNullOrWhiteSpace(race.AdditionalProperties?.Organizer))
+        throw new FISExportException("missing raceorganizer");
+      writeElement("Raceorganizer", race.AdditionalProperties?.Organizer);
+
+      if (!string.IsNullOrWhiteSpace(race.AdditionalProperties?.RaceNation))
+        writeElement("Nation", race.AdditionalProperties.RaceNation);
+
+      writeElement("Discipline", getFISDiscipline(race));
+
+      if (!string.IsNullOrWhiteSpace(race.AdditionalProperties?.FISCategory))
+        writeElement("Category", race.AdditionalProperties.FISCategory);
+
+      if (string.IsNullOrWhiteSpace(race.Description))
+        throw new FISExportException("missing racename");
+      writeElement("Racename", race.Description);
+
+      if (string.IsNullOrWhiteSpace(race.AdditionalProperties?.Location))
+        throw new FISExportException("missing raceplace");
+      writeElement("Raceplace", race.AdditionalProperties?.Location);
+
+      writeElement("Timing", string.IsNullOrWhiteSpace(race.TimingDevice) ? "Race Horology" : race.TimingDevice);
+
+      if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Club) && !string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Name))
+        writeElement("Dataprocessing_by", string.Format("{0}, {1}", race.AdditionalProperties?.Analyzer.Name, race.AdditionalProperties?.Analyzer.Club));
+      else if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Club))
+        writeElement("Dataprocessing_by", race.AdditionalProperties?.Analyzer.Club);
+      else if (!string.IsNullOrEmpty(race.AdditionalProperties?.Analyzer.Name))
+        writeElement("Dataprocessing_by", race.AdditionalProperties?.Analyzer.Name);
+
+      string software = getSoftware();
+      if (software != null)
+        writeElement("Software", software);
+
+      _writer.WriteEndElement();
+    }
+
+
+    void writeALRaceinfo(Race race)
+    {
+      _writer.WriteStartElement("AL_raceinfo");
+
+      FISRaceResultViewProvider fisRaceVP = race.GetResultViewProvider() as FISRaceResultViewProvider;
+      if (fisRaceVP != null)
+      {
+        if (race.RaceConfiguration.ValueF > 0.0)
+          writeElement("Fvalue", race.RaceConfiguration.ValueF.ToString("F0", CultureInfo.InvariantCulture));
+
+        FISRaceCalculation fisCalc = fisRaceVP.GetFISRaceCalculation();
+        if (fisCalc != null && fisCalc.CalculationValid)
+        {
+          writeElement("Appliedpenalty", fisCalc.AppliedPenalty.ToString("F2", CultureInfo.InvariantCulture));
+          writeElement("Calculatedpenalty", fisCalc.CalculatedPenalty.ToString("F2", CultureInfo.InvariantCulture));
+        }
+      }
+
+      if (race.AdditionalProperties?.RaceManager == null || ((AdditionalRaceProperties.Person)race.AdditionalProperties?.RaceManager).IsEmpty())
+        throw new FISExportException("missing racejury Chiefrace");
+      writeJury("Chiefrace", race.AdditionalProperties?.RaceManager);
+
+      if (race.AdditionalProperties?.RaceReferee == null || ((AdditionalRaceProperties.Person)race.AdditionalProperties?.RaceReferee).IsEmpty())
+        throw new FISExportException("missing racejury Referee");
+      writeJury("Referee", race.AdditionalProperties?.RaceReferee);
+
+      if (race.RaceType == Race.ERaceType.SuperG || race.RaceType == Race.ERaceType.DownHill)
+      {
+        if (race.AdditionalProperties?.AssistantReferee == null || ((AdditionalRaceProperties.Person)race.AdditionalProperties?.AssistantReferee).IsEmpty())
+          throw new FISExportException("missing racejury Assistantreferee");
+      }
+      if (race.AdditionalProperties?.AssistantReferee != null && !((AdditionalRaceProperties.Person)race.AdditionalProperties?.AssistantReferee).IsEmpty())
+        writeJury("Assistantreferee", race.AdditionalProperties?.AssistantReferee);
+
+      if (race.AdditionalProperties?.TrainerRepresentative == null || ((AdditionalRaceProperties.Person)race.AdditionalProperties?.TrainerRepresentative).IsEmpty())
+        throw new FISExportException("missing racejury TD");
+      writeJury("TD", race.AdditionalProperties?.TrainerRepresentative);
+
+      writeRuninfo(race.GetRun(0), race.AdditionalProperties?.RaceRun1);
+      if (race.GetMaxRun() > 1)
+        writeRuninfo(race.GetRun(1), race.AdditionalProperties?.RaceRun2);
+
+      _writer.WriteEndElement();
+    }
+
+
+    void writeJury(string function, AdditionalRaceProperties.Person person)
+    {
+      string lastname, firstname;
+      DSVExport.guessLastAndFirstname(person?.Name, out lastname, out firstname);
+
+      _writer.WriteStartElement("Jury");
+      _writer.WriteAttributeString("Function", function);
+      writeElement("Jurylastname", lastname);
+      writeElement("Juryfirstname", firstname);
+      if (!string.IsNullOrEmpty(person?.Club))
+        writeElement("Jurynation", person.Club);
+      _writer.WriteEndElement();
+    }
+
+
+    void writeRuninfo(RaceRun raceRun, AdditionalRaceProperties.RaceRunProperties raceRunProperties)
+    {
+      _writer.WriteStartElement("Runinfo");
+      _writer.WriteAttributeString("Run", raceRun.Run.ToString());
+
+      if (string.IsNullOrEmpty(raceRun.GetRace().AdditionalProperties?.CoarseName))
+        throw new FISExportException("missing coarsename");
+      writeElement("Coursename", raceRun.GetRace().AdditionalProperties?.CoarseName);
+
+      if (!string.IsNullOrEmpty(raceRun.GetRace().AdditionalProperties?.CoarseHomologNo))
+        writeElement("Homologationnumber", raceRun.GetRace().AdditionalProperties.CoarseHomologNo);
+
+      if (raceRunProperties.Gates <= 0)
+        throw new FISExportException("missing number_of_gates");
+      writeElement("Numberofgates", raceRunProperties.Gates.ToString());
+
+      if (raceRunProperties.Turns <= 0)
+        throw new FISExportException("missing number_of_turninggates");
+      writeElement("Numberofturninggates", raceRunProperties.Turns.ToString());
+
+      if (raceRun.GetRace().AdditionalProperties?.StartHeight <= 0)
+        throw new FISExportException("missing startaltitude");
+      writeElement("Startaltitude", raceRun.GetRace().AdditionalProperties?.StartHeight.ToString());
+
+      if (raceRun.GetRace().AdditionalProperties?.FinishHeight <= 0)
+        throw new FISExportException("missing finishaltitude");
+      writeElement("Finishaltitude", raceRun.GetRace().AdditionalProperties?.FinishHeight.ToString());
+
+      if (raceRun.GetRace().AdditionalProperties?.CoarseLength <= 0)
+        throw new FISExportException("missing courselength");
+      writeElement("Courselength", raceRun.GetRace().AdditionalProperties.CoarseLength.ToString());
+
+      writeCoursesetter(raceRunProperties.CoarseSetter);
+
+      if (!string.IsNullOrWhiteSpace(raceRunProperties.Forerunner1.Name))
+        writeForerunner(1, raceRunProperties.Forerunner1);
+      else
+        throw new FISExportException("missing forerunner");
+      if (!string.IsNullOrWhiteSpace(raceRunProperties.Forerunner2.Name))
+        writeForerunner(2, raceRunProperties.Forerunner2);
+      if (!string.IsNullOrWhiteSpace(raceRunProperties.Forerunner3.Name))
+        writeForerunner(3, raceRunProperties.Forerunner3);
+
+      writeElement("Starttime", raceRunProperties.StartTime);
+
+      _writer.WriteEndElement();
+    }
+
+
+    void writeCoursesetter(AdditionalRaceProperties.Person person)
+    {
+      if (person == null || person.IsEmpty())
+        throw new FISExportException("missing coursesetter");
+
+      string lastname, firstname;
+      DSVExport.guessLastAndFirstname(person?.Name, out lastname, out firstname);
+
+      _writer.WriteStartElement("Coursesetter");
+      writeElement("Lastname", lastname);
+      if (!string.IsNullOrEmpty(firstname))
+        writeElement("Firstname", firstname);
+      if (!string.IsNullOrEmpty(person?.Club))
+        writeElement("Nation", person.Club);
+      _writer.WriteEndElement();
+    }
+
+
+    void writeForerunner(int order, AdditionalRaceProperties.Person person)
+    {
+      string lastname, firstname;
+      DSVExport.guessLastAndFirstname(person?.Name, out lastname, out firstname);
+
+      _writer.WriteStartElement("Forerunner");
+      _writer.WriteAttributeString("Order", order.ToString());
+      writeElement("Lastname", lastname);
+      if (!string.IsNullOrEmpty(firstname))
+        writeElement("Firstname", firstname);
+      if (!string.IsNullOrEmpty(person?.Club))
+        writeElement("Nation", person.Club);
+      _writer.WriteEndElement();
+    }
+
+
+    void writeRaceResults(Race race)
+    {
+      List<RaceResultItem> classified = new List<RaceResultItem>();
+      List<RaceResultItem> notClassified = new List<RaceResultItem>();
+
+      var results = race.GetResultViewProvider().GetView();
+
+      foreach (var result in results.SourceCollection)
+      {
+        RaceResultItem item = result as RaceResultItem;
+
+        if (item.ResultCode == RunResult.EResultCode.Normal && item.TotalTime != null)
+          classified.Add(item);
+        else
+          notClassified.Add(item);
+      }
+
+      writeALClassified(classified);
+      writeALNotClassified(notClassified);
+    }
+
+
+    void writeALClassified(List<RaceResultItem> classified)
+    {
+      _writer.WriteStartElement("AL_classified");
+
+      foreach (RaceResultItem rri in classified)
+      {
+        _writer.WriteStartElement("AL_ranked");
+        _writer.WriteAttributeString("Status", "QLF");
+
+        writeElement("Rank", rri.Position.ToString());
+        writeElement("Bib", rri.Participant.StartNumber.ToString());
+        writeCompetitor(rri.Participant);
+
+        foreach (var x in rri.SubResults.OrderBy(k => k.Key))
+        {
+          writeElement("Timerun" + x.Key, formatTime(x.Value.Runtime));
+        }
+
+        writeElement("Totaltime", formatTime(rri.TotalTime));
+
+        if (_writePoints && rri.Points >= 0)
+          writeElement("Racepoints", rri.Points.ToString("F2", CultureInfo.InvariantCulture));
+
+        _writer.WriteEndElement();
+      }
+
+      _writer.WriteEndElement();
+    }
+
+
+    void writeALNotClassified(List<RaceResultItem> notClassified)
+    {
+      _writer.WriteStartElement("AL_notclassified");
+
+      foreach (RaceResultItem rri in notClassified)
+      {
+        string status;
+        uint failedRun;
+        mapNotClassifiedStatus(rri, out status, out failedRun);
+
+        _writer.WriteStartElement("AL_notranked");
+        _writer.WriteAttributeString("Status", status);
+
+        writeElement("Bib", rri.Participant.StartNumber.ToString());
+        writeCompetitor(rri.Participant);
+
+        if (failedRun > 0)
+          writeElement("Run", failedRun.ToString());
+
+        if (!string.IsNullOrWhiteSpace(rri.DisqualText))
+          writeElement("Reason", rri.DisqualText);
+
+        _writer.WriteEndElement();
+      }
+
+      _writer.WriteEndElement();
+    }
+
+
+    void writeCompetitor(RaceParticipant participant)
+    {
+      _writer.WriteStartElement("Competitor");
+
+      writeElement("Fiscode", participant.Participant.CodeOrSvId);
+
+      writeElement("Lastname", participant.Name);
+      writeElement("Firstname", participant.Firstname);
+
+      writeElement("Year", participant.Participant.Year.ToString());
+
+      writeElement("Nation", participant.Nation);
+
+      writeElement("Club", participant.Club);
+
+      _writer.WriteEndElement();
+    }
+
+
+    void writeElement(string name, string value)
+    {
+      _writer.WriteStartElement(name);
+      _writer.WriteValue(value ?? "");
+      _writer.WriteEndElement();
+    }
+
+
+    static string formatTime(TimeSpan? time)
+    {
+      return time?.ToString(@"mm\:ss\.ff");
+    }
+
+
+    static string getFISDiscipline(Race race)
+    {
+      if (race.RaceType == Race.ERaceType.DownHill)
+        return "DH";
+      if (race.RaceType == Race.ERaceType.GiantSlalom)
+        return "GS";
+      if (race.RaceType == Race.ERaceType.ParallelSlalom)
+        return "PSL";
+      if (race.RaceType == Race.ERaceType.Slalom)
+        return "SL";
+      if (race.RaceType == Race.ERaceType.SuperG)
+        return "SG";
+
+      throw new FISExportException("not supported racetype");
+    }
+
+
+    static void mapNotClassifiedStatus(RaceResultItem rri, out string status, out uint failedRun)
+    {
+      status = "UNKNOWN";
+      failedRun = 0;
+
+      foreach (KeyValuePair<uint, RaceResultItem.SubResult> kvp in rri.SubResults.OrderBy(k => k.Key))
+      {
+        if (kvp.Value.RunResultCode != RunResult.EResultCode.Normal)
+        {
+          status = mapResultCode(kvp.Value.RunResultCode);
+          failedRun = kvp.Key;
+          break;
+        }
+      }
+    }
+
+    static string mapResultCode(RunResult.EResultCode resultCode)
+    {
+      switch (resultCode)
+      {
+        case RunResult.EResultCode.DIS:
+          return "DSQ";
+        case RunResult.EResultCode.NaS:
+          return "DNS";
+        case RunResult.EResultCode.NiZ:
+          return "DNF";
+        case RunResult.EResultCode.NQ:
+          return "DNQ";
+      }
+
+      return "UNKNOWN";
+    }
+
+
+    string getSoftware()
+    {
+      Assembly assembly = Assembly.GetEntryAssembly();
+      if (assembly == null)
+        assembly = Assembly.GetExecutingAssembly();
+
+      if (assembly != null)
+      {
+        FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+        var productName = fvi.ProductName;
+        var productVersion = fvi.ProductVersion;
+
+        return string.Format("{0} {1}", productName, productVersion);
+      }
+
+      return null;
+    }
+  }
+}

--- a/RaceHorologyLib/FISExport.cs
+++ b/RaceHorologyLib/FISExport.cs
@@ -517,9 +517,6 @@ namespace RaceHorologyLib
 
       writeElement("Yearofbirth", participant.Participant.Year.ToString());
 
-      if (!string.IsNullOrEmpty(participant.Club))
-        writeElement("Clubname", participant.Club);
-
       _writer.WriteEndElement();
     }
 

--- a/RaceHorologyLib/FISExport.cs
+++ b/RaceHorologyLib/FISExport.cs
@@ -35,14 +35,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Xml;
 
@@ -107,7 +105,6 @@ namespace RaceHorologyLib
   {
     protected XmlWriterSettings _xmlSettings;
     protected XmlWriter _writer;
-    protected bool _writePoints;
 
     public FISExport()
     {
@@ -168,8 +165,6 @@ namespace RaceHorologyLib
 
     public void ExportXML(Stream output, Race race)
     {
-      _writePoints = race.RaceConfiguration.ActiveFields.Contains("Points");
-
       _writer = XmlWriter.Create(output, _xmlSettings);
 
       _writer.WriteStartDocument();
@@ -293,10 +288,6 @@ namespace RaceHorologyLib
         writeElement("Dataprocessingby", race.AdditionalProperties?.Analyzer.Name);
 
       writeElement("Softwarename", "RaceHorology");
-
-      string gitHash = getGitHash();
-      if (!string.IsNullOrEmpty(gitHash))
-        writeElement("Softwareversion", gitHash);
 
       _writer.WriteEndElement();
     }
@@ -438,12 +429,13 @@ namespace RaceHorologyLib
           notClassified.Add(item);
       }
 
-      writeALClassified(classified);
+      FISRaceCalculation fisCalc = (race.GetResultViewProvider() as FISRaceResultViewProvider)?.GetFISRaceCalculation();
+      writeALClassified(classified, fisCalc);
       writeALNotClassified(notClassified);
     }
 
 
-    void writeALClassified(List<RaceResultItem> classified)
+    void writeALClassified(List<RaceResultItem> classified, FISRaceCalculation fisCalc)
     {
       _writer.WriteStartElement("AL_classified");
 
@@ -463,8 +455,9 @@ namespace RaceHorologyLib
         }
         writeElement("Totaltime", formatTime(rri.TotalTime));
 
-        if (_writePoints && rri.Points >= 0)
-          writeElement("Racepoints", rri.Points.ToString("F2", CultureInfo.InvariantCulture));
+        double racePoints = fisCalc != null ? fisCalc.CalculatePoints(rri, false) : -1.0;
+        if (racePoints >= 0)
+          writeElement("Racepoints", racePoints.ToString("F2", CultureInfo.InvariantCulture));
 
         _writer.WriteEndElement(); // AL_result
 
@@ -617,36 +610,5 @@ namespace RaceHorologyLib
     }
 
 
-    static string getGitHash()
-    {
-      try
-      {
-        var process = new Process();
-        process.StartInfo.FileName = "git";
-        process.StartInfo.Arguments = "rev-parse --short HEAD";
-        process.StartInfo.UseShellExecute = false;
-        process.StartInfo.RedirectStandardOutput = true;
-        process.StartInfo.CreateNoWindow = true;
-        process.Start();
-        string hash = process.StandardOutput.ReadToEnd().Trim();
-        process.WaitForExit();
-        if (process.ExitCode == 0 && !string.IsNullOrEmpty(hash))
-          return hash;
-      }
-      catch { }
-
-      try
-      {
-        Assembly assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
-        if (assembly != null)
-        {
-          FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
-          return fvi.ProductVersion;
-        }
-      }
-      catch { }
-
-      return null;
-    }
   }
 }

--- a/RaceHorologyLib/RaceHorologyLib.csproj
+++ b/RaceHorologyLib/RaceHorologyLib.csproj
@@ -87,6 +87,7 @@
     <Compile Include="DSVAlpin2HTTPServer.cs" />
     <Compile Include="DSVCalculations.cs" />
     <Compile Include="DSVExport.cs" />
+    <Compile Include="FISExport.cs" />
     <Compile Include="FISCalculations.cs" />
     <Compile Include="FISImport.cs" />
     <Compile Include="DSVImport.cs" />

--- a/RaceHorologyLibTest/FISExportTest.cs
+++ b/RaceHorologyLibTest/FISExportTest.cs
@@ -1,0 +1,403 @@
+/*
+ *  Copyright (C) 2019 - 2026 by Sven Flossmann & Co-Authors (CREDITS.TXT)
+ *
+ *  This file is part of Race Horology.
+ *
+ *  Race Horology is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  Race Horology is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with Race Horology.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Diese Datei ist Teil von Race Horology.
+ *
+ *  Race Horology ist Freie Software: Sie können es unter den Bedingungen
+ *  der GNU Affero General Public License, wie von der Free Software Foundation,
+ *  Version 3 der Lizenz oder (nach Ihrer Wahl) jeder neueren
+ *  veröffentlichten Version, weiter verteilen und/oder modifizieren.
+ *
+ *  Race Horology wird in der Hoffnung, dass es nützlich sein wird, aber
+ *  OHNE JEDE GEWÄHRLEISTUNG, bereitgestellt; sogar ohne die implizite
+ *  Gewährleistung der MARKTFÄHIGKEIT oder EIGNUNG FÜR EINEN BESTIMMTEN ZWECK.
+ *  Siehe die GNU Affero General Public License für weitere Details.
+ *
+ *  Sie sollten eine Kopie der GNU Affero General Public License zusammen mit diesem
+ *  Programm erhalten haben. Wenn nicht, siehe <https://www.gnu.org/licenses/>.
+ *
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RaceHorologyLib;
+using System;
+using System.IO;
+using System.Threading;
+using XmlUnit.Xunit;
+
+namespace RaceHorologyLibTest
+{
+  [TestClass]
+  public class FISExportTest
+  {
+    public FISExportTest()
+    {
+      SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+    }
+
+    private TestContext testContextInstance;
+
+    public TestContext TestContext
+    {
+      get { return testContextInstance; }
+      set { testContextInstance = value; }
+    }
+
+
+    [TestMethod]
+    public void BasicExceptions_MandatoryFields()
+    {
+      var model = createTestDataModel1Race1Run();
+
+      FISExport fisExport = new FISExport();
+      MemoryStream xmlData = null;
+
+      var raceProps = new AdditionalRaceProperties();
+      model.GetRace(0).AdditionalProperties = raceProps;
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing racedate",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.DateResultList = DateTime.Today;
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing raceid",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.RaceNumber = "1234";
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing raceorganizer",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.Organizer = "WSV Glonn";
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing racename",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.Description = "Test Race";
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing raceplace",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.Location = "Test Location";
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing racejury Chiefrace",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.RaceManager = new AdditionalRaceProperties.Person { Name = "Race Manager", Club = "Club" };
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing racejury Referee",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.RaceReferee = new AdditionalRaceProperties.Person { Name = "Race Referee", Club = "Club" };
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing racejury TD",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.TrainerRepresentative = new AdditionalRaceProperties.Person { Name = "TD Person", Club = "Club" };
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing coarsename",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.CoarseName = "Kurs 1";
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing number_of_gates",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.RaceRun1.Gates = 10;
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing number_of_turninggates",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.RaceRun1.Turns = 9;
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing startaltitude",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.StartHeight = 1000;
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing finishaltitude",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.FinishHeight = 100;
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing courselength",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.CoarseLength = 1000;
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing coursesetter",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.RaceRun1.CoarseSetter = new AdditionalRaceProperties.Person { Name = "Sven Flossmann", Club = "WSV Glonn" };
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing forerunner",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.RaceRun1.Forerunner1 = new AdditionalRaceProperties.Person { Name = "Fore Runner", Club = "WSV Glonn" };
+
+      xmlData = new MemoryStream();
+      fisExport.ExportXML(xmlData, model.GetRace(0));
+    }
+
+
+    [TestMethod]
+    public void AssistantReferee_MandatoryForSGAndDH()
+    {
+      var modelSG = new AppDataModel(new DummyDataBase("dummy"));
+      modelSG.AddRace(new Race.RaceProperties { RaceType = Race.ERaceType.SuperG, Runs = 1 });
+      fillMandatoryFields(modelSG);
+
+      FISExport fisExport = new FISExport();
+      MemoryStream xmlData = new MemoryStream();
+      Assert.AreEqual("missing racejury Assistantreferee",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, modelSG.GetRace(0))).Message);
+
+      modelSG.GetRace(0).AdditionalProperties.AssistantReferee = new AdditionalRaceProperties.Person { Name = "Asst Ref", Club = "Club" };
+      xmlData = new MemoryStream();
+      fisExport.ExportXML(xmlData, modelSG.GetRace(0));
+
+      var modelDH = new AppDataModel(new DummyDataBase("dummy"));
+      modelDH.AddRace(new Race.RaceProperties { RaceType = Race.ERaceType.DownHill, Runs = 1 });
+      fillMandatoryFields(modelDH);
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing racejury Assistantreferee",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, modelDH.GetRace(0))).Message);
+    }
+
+
+    [TestMethod]
+    public void AssistantReferee_OptionalForSlalom()
+    {
+      var model = createTestDataModel1Race1Run();
+      fillMandatoryFields(model);
+
+      FISExport fisExport = new FISExport();
+      MemoryStream xmlData = new MemoryStream();
+      fisExport.ExportXML(xmlData, model.GetRace(0));
+    }
+
+
+    [TestMethod]
+    public void VerifyXML_MandatoryFields()
+    {
+      var model = createTestDataModel1Race1Run();
+      fillMandatoryFields(model);
+
+      string s = exportToXML(model.GetRace(0));
+
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racedate", s, DateTime.Today.ToString("yyyy-MM-dd"));
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Gender", s, "A");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Raceid", s, "1234");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Raceorganizer", s, "WSV Glonn");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Discipline", s, "GS");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racename", s, "Test Race");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Raceplace", s, "Test Location");
+
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='Chiefrace']/Jurylastname", s, "Manager");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='Chiefrace']/Juryfirstname", s, "Race");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='Referee']/Jurylastname", s, "Referee");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='Referee']/Juryfirstname", s, "Race");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='TD']/Jurylastname", s, "Rep");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='TD']/Juryfirstname", s, "T.");
+
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Coursename", s, "Kurs 1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Numberofgates", s, "10");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Numberofturninggates", s, "9");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Startaltitude", s, "1000");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Finishaltitude", s, "100");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Courselength", s, "1000");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Coursesetter/Lastname", s, "Flossmann");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Coursesetter/Firstname", s, "Sven");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Coursesetter/Nation", s, "WSV Glonn");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Forerunner[1]/Lastname", s, "Runner");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Forerunner[1]/Firstname", s, "F.");
+    }
+
+
+    [TestMethod]
+    public void VerifyXML_FISDisciplineCode()
+    {
+      var model = createTestDataModel1Race1Run();
+      fillMandatoryFields(model);
+
+      string s = exportToXML(model.GetRace(0));
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Discipline", s, "GS");
+    }
+
+
+    [TestMethod]
+    public void VerifyXML_NationAndCategory()
+    {
+      var model = createTestDataModel1Race1Run();
+      fillMandatoryFields(model);
+
+      string s = exportToXML(model.GetRace(0));
+      Assert.ThrowsException<Xunit.Sdk.TrueException>(() => XmlAssertion.AssertXPathExists("/Fisresults/Raceheader/Nation", s));
+      Assert.ThrowsException<Xunit.Sdk.TrueException>(() => XmlAssertion.AssertXPathExists("/Fisresults/Raceheader/Category", s));
+
+      model.GetRace(0).AdditionalProperties.RaceNation = "GER";
+      model.GetRace(0).AdditionalProperties.FISCategory = "FIS";
+      s = exportToXML(model.GetRace(0));
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Nation", s, "GER");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Category", s, "FIS");
+    }
+
+
+    [TestMethod]
+    public void VerifyXML_NoWeatherData()
+    {
+      var model = createTestDataModel1Race1Run();
+      fillMandatoryFields(model);
+      model.GetRace(0).AdditionalProperties.Weather = "sunny";
+      model.GetRace(0).AdditionalProperties.Snow = "griffig";
+      model.GetRace(0).AdditionalProperties.TempStart = "-2";
+      model.GetRace(0).AdditionalProperties.TempFinish = "-1";
+
+      string s = exportToXML(model.GetRace(0));
+      Assert.IsFalse(s.Contains("meteodata"));
+      Assert.IsFalse(s.Contains("Snow"));
+      Assert.IsFalse(s.Contains("Weather"));
+      Assert.IsFalse(s.Contains("Temperature"));
+    }
+
+
+    [TestMethod]
+    public void VerifyXML_ResultsWithRuns()
+    {
+      TestDataGenerator tg = new TestDataGenerator();
+      fillMandatoryFields(tg.Model);
+
+      tg.Model.GetRace(0).GetRun(0).SetStartFinishTime(tg.createRaceParticipant(cat: tg.findCat('M')), new TimeSpan(0, 8, 0, 0), new TimeSpan(0, 8, 0, 2));
+      tg.Model.GetRace(0).GetRun(0).SetStartFinishTime(tg.createRaceParticipant(cat: tg.findCat('M')), new TimeSpan(0, 8, 1, 0), new TimeSpan(0, 8, 1, 4));
+      tg.Model.GetRace(0).GetRun(0).SetStartFinishTime(tg.createRaceParticipant(cat: tg.findCat('M')), new TimeSpan(0, 8, 2, 0), new TimeSpan(0, 8, 2, 3));
+      tg.Model.GetRace(0).GetRun(0).SetStartFinishTime(tg.createRaceParticipant(cat: tg.findCat('M')), new TimeSpan(0, 8, 2, 0), null);
+      tg.Model.GetRace(0).GetRun(0).SetResultCode(tg.Model.GetRace(0).GetParticipant(4), RunResult.EResultCode.NiZ);
+      tg.Model.GetRace(0).GetRun(0).SetResultCode(tg.createRaceParticipant(cat: tg.findCat('M')), RunResult.EResultCode.NaS);
+      tg.Model.GetRace(0).GetRun(0).SetResultCode(tg.createRaceParticipant(cat: tg.findCat('M')), RunResult.EResultCode.DIS, "Tor 2");
+
+      tg.Model.GetRace(0).GetRun(1).SetStartFinishTime(tg.Model.GetRace(0).GetParticipant(1), new TimeSpan(0, 9, 0, 0), new TimeSpan(0, 9, 0, 3));
+      tg.Model.GetRace(0).GetRun(1).SetStartFinishTime(tg.Model.GetRace(0).GetParticipant(2), new TimeSpan(0, 9, 1, 0), null);
+      tg.Model.GetRace(0).GetRun(1).SetResultCode(tg.Model.GetRace(0).GetParticipant(2), RunResult.EResultCode.NiZ);
+      tg.Model.GetRace(0).GetRun(1).SetResultCode(tg.Model.GetRace(0).GetParticipant(3), RunResult.EResultCode.DIS, "Tor 1");
+
+      string s = exportToXML(tg.Model.GetRace(0));
+
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_classified/AL_ranked[@Status='QLF']/Bib", s, "1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_classified/AL_ranked/Timerun1", s, "00:02.00");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_classified/AL_ranked/Timerun2", s, "00:03.00");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_classified/AL_ranked/Totaltime", s, "00:05.00");
+
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DNF']/Bib[text()='2']/../Run", s, "2");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='3']/../Run", s, "2");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DNF']/Bib[text()='4']/../Run", s, "1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DNS']/Bib[text()='5']/../Run", s, "1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='6']/../Run", s, "1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='6']/../Reason", s, "Tor 2");
+    }
+
+
+    [TestMethod]
+    public void VerifyXML_NotClassifiedStatusHasNoRunNumber()
+    {
+      TestDataGenerator tg = new TestDataGenerator();
+      fillMandatoryFields(tg.Model);
+
+      tg.Model.GetRace(0).GetRun(0).SetStartFinishTime(tg.createRaceParticipant(cat: tg.findCat('M')), new TimeSpan(0, 8, 0, 0), null);
+      tg.Model.GetRace(0).GetRun(0).SetResultCode(tg.Model.GetRace(0).GetParticipant(1), RunResult.EResultCode.NiZ);
+
+      string s = exportToXML(tg.Model.GetRace(0));
+
+      Assert.IsFalse(s.Contains("DNF1"), "Status should not contain run number appended");
+      Assert.IsTrue(s.Contains("Status=\"DNF\""), "Status should be plain DNF without run number");
+      Assert.IsTrue(s.Contains("<Run>1</Run>"), "Run should be a separate element");
+    }
+
+
+    [TestMethod]
+    public void VerifyXML_FvalueInRaceinfo()
+    {
+      var model = createTestDataModel1Race1Run();
+      fillMandatoryFields(model);
+
+      string s = exportToXML(model.GetRace(0));
+
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Fvalue", s, "720");
+    }
+
+
+    string exportToXML(Race race)
+    {
+      FISExport fisExport = new FISExport();
+      MemoryStream xmlData = new MemoryStream();
+      fisExport.ExportXML(xmlData, race);
+
+      xmlData.Position = 0;
+      StreamReader reader = new StreamReader(xmlData);
+      return reader.ReadToEnd();
+    }
+
+
+    private AppDataModel createTestDataModel1Race1Run()
+    {
+      AppDataModel dm = new AppDataModel(new DummyDataBase("dummy"));
+      dm.AddRace(new Race.RaceProperties { RaceType = Race.ERaceType.GiantSlalom, Runs = 1 });
+      return dm;
+    }
+
+
+    void fillMandatoryFields(AppDataModel model)
+    {
+      var raceProps = new AdditionalRaceProperties();
+      model.GetRace(0).AdditionalProperties = raceProps;
+      raceProps.DateResultList = DateTime.Today;
+      raceProps.RaceNumber = "1234";
+      raceProps.Organizer = "WSV Glonn";
+      raceProps.Description = "Test Race";
+      raceProps.Location = "Test Location";
+
+      raceProps.RaceManager = new AdditionalRaceProperties.Person { Name = "Race Manager", Club = "Club" };
+      raceProps.RaceReferee = new AdditionalRaceProperties.Person { Name = "Referee, Race", Club = "Club" };
+      raceProps.TrainerRepresentative = new AdditionalRaceProperties.Person { Name = "T.Rep", Club = "Club" };
+
+      raceProps.CoarseName = "Kurs 1";
+      raceProps.StartHeight = 1000;
+      raceProps.FinishHeight = 100;
+      raceProps.CoarseLength = 1000;
+
+      raceProps.RaceRun1.Gates = 10;
+      raceProps.RaceRun1.Turns = 9;
+      raceProps.RaceRun1.CoarseSetter = new AdditionalRaceProperties.Person { Name = "Sven Flossmann", Club = "WSV Glonn" };
+      raceProps.RaceRun1.Forerunner1 = new AdditionalRaceProperties.Person { Name = "F. Runner", Club = "WSV Glonn" };
+
+      if (model.GetRace(0).GetMaxRun() > 1)
+      {
+        raceProps.RaceRun2.Gates = 10;
+        raceProps.RaceRun2.Turns = 9;
+        raceProps.RaceRun2.CoarseSetter = new AdditionalRaceProperties.Person { Name = "Sven Flossmann", Club = "WSV Glonn" };
+        raceProps.RaceRun2.Forerunner1 = new AdditionalRaceProperties.Person { Name = "F. Runner", Club = "WSV Glonn" };
+      }
+
+      model.GetRace(0).RaceConfiguration.ValueF = 720.0;
+
+      var rvp = new FISRaceResultViewProvider();
+      rvp.Init(model.GetRace(0), model);
+      model.GetRace(0).SetResultViewProvider(rvp);
+    }
+  }
+}

--- a/RaceHorologyLibTest/FISExportTest.cs
+++ b/RaceHorologyLibTest/FISExportTest.cs
@@ -71,14 +71,14 @@ namespace RaceHorologyLibTest
       model.GetRace(0).AdditionalProperties = raceProps;
 
       xmlData = new MemoryStream();
-      Assert.AreEqual("missing racedate",
-        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
-      raceProps.DateResultList = DateTime.Today;
-
-      xmlData = new MemoryStream();
       Assert.AreEqual("missing raceid",
         Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
       raceProps.RaceNumber = "1234";
+
+      xmlData = new MemoryStream();
+      Assert.AreEqual("missing racedate",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.DateResultList = DateTime.Today;
 
       xmlData = new MemoryStream();
       Assert.AreEqual("missing raceorganizer",
@@ -86,14 +86,19 @@ namespace RaceHorologyLibTest
       raceProps.Organizer = "WSV Glonn";
 
       xmlData = new MemoryStream();
+      Assert.AreEqual("missing raceplace",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.Location = "Test Location";
+
+      xmlData = new MemoryStream();
       Assert.AreEqual("missing racename",
         Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
       raceProps.Description = "Test Race";
 
       xmlData = new MemoryStream();
-      Assert.AreEqual("missing raceplace",
+      Assert.AreEqual("missing racejury TechnicalDelegate",
         Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
-      raceProps.Location = "Test Location";
+      raceProps.TrainerRepresentative = new AdditionalRaceProperties.Person { Name = "TD Person", Club = "Club" };
 
       xmlData = new MemoryStream();
       Assert.AreEqual("missing racejury Chiefrace",
@@ -104,11 +109,6 @@ namespace RaceHorologyLibTest
       Assert.AreEqual("missing racejury Referee",
         Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
       raceProps.RaceReferee = new AdditionalRaceProperties.Person { Name = "Race Referee", Club = "Club" };
-
-      xmlData = new MemoryStream();
-      Assert.AreEqual("missing racejury TD",
-        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
-      raceProps.TrainerRepresentative = new AdditionalRaceProperties.Person { Name = "TD Person", Club = "Club" };
 
       xmlData = new MemoryStream();
       Assert.AreEqual("missing coarsename",
@@ -126,6 +126,11 @@ namespace RaceHorologyLibTest
       raceProps.RaceRun1.Turns = 9;
 
       xmlData = new MemoryStream();
+      Assert.AreEqual("missing courselength",
+        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
+      raceProps.CoarseLength = 1000;
+
+      xmlData = new MemoryStream();
       Assert.AreEqual("missing startaltitude",
         Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
       raceProps.StartHeight = 1000;
@@ -134,11 +139,6 @@ namespace RaceHorologyLibTest
       Assert.AreEqual("missing finishaltitude",
         Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
       raceProps.FinishHeight = 100;
-
-      xmlData = new MemoryStream();
-      Assert.AreEqual("missing courselength",
-        Assert.ThrowsException<FISExportException>(() => fisExport.ExportXML(xmlData, model.GetRace(0))).Message);
-      raceProps.CoarseLength = 1000;
 
       xmlData = new MemoryStream();
       Assert.AreEqual("missing coursesetter",
@@ -201,32 +201,37 @@ namespace RaceHorologyLibTest
 
       string s = exportToXML(model.GetRace(0));
 
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racedate", s, DateTime.Today.ToString("yyyy-MM-dd"));
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Gender", s, "A");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Raceid", s, "1234");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Raceorganizer", s, "WSV Glonn");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/@Sector", s, "AL");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/@Gender", s, "A");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racedate/Day", s, DateTime.Today.Day.ToString());
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racedate/Month", s, DateTime.Today.Month.ToString());
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racedate/Year", s, DateTime.Today.Year.ToString());
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Codex", s, "1234");
       XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Discipline", s, "GS");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racename", s, "Test Race");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Raceplace", s, "Test Location");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Eventname", s, "Test Race");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Place", s, "Test Location");
 
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='Chiefrace']/Jurylastname", s, "Manager");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='Chiefrace']/Juryfirstname", s, "Race");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='Referee']/Jurylastname", s, "Referee");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='Referee']/Juryfirstname", s, "Race");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='TD']/Jurylastname", s, "Rep");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Jury[@Function='TD']/Juryfirstname", s, "T.");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Jury[@Function='TechnicalDelegate']/Lastname", s, "Rep");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Jury[@Function='TechnicalDelegate']/Firstname", s, "T.");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Jury[@Function='Chiefrace']/Lastname", s, "Manager");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Jury[@Function='Chiefrace']/Firstname", s, "Race");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Jury[@Function='Referee']/Lastname", s, "Referee");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Jury[@Function='Referee']/Firstname", s, "Race");
 
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Coursename", s, "Kurs 1");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Numberofgates", s, "10");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Numberofturninggates", s, "9");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Startaltitude", s, "1000");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Finishaltitude", s, "100");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Courselength", s, "1000");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Coursesetter/Lastname", s, "Flossmann");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Coursesetter/Firstname", s, "Sven");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Coursesetter/Nation", s, "WSV Glonn");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Forerunner[1]/Lastname", s, "Runner");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Runinfo[1]/Forerunner[1]/Firstname", s, "F.");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Name", s, "Kurs 1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Gates", s, "10");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Turninggates", s, "9");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Startelev", s, "1000");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Finishelev", s, "100");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Length", s, "1000");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Coursesetter/Lastname", s, "Flossmann");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Coursesetter/Firstname", s, "Sven");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Coursesetter/Nation", s, "WSV Glonn");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Forerunner[1]/Lastname", s, "Runner");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Runinfo[1]/Course/Forerunner[1]/Firstname", s, "F.");
+
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Softwarename", s, "RaceHorology");
+      Assert.IsTrue(s.Contains("<Timingby>"));
     }
 
 
@@ -278,6 +283,18 @@ namespace RaceHorologyLibTest
 
 
     [TestMethod]
+    public void VerifyXML_TDNumber()
+    {
+      var model = createTestDataModel1Race1Run();
+      fillMandatoryFields(model);
+      model.GetRace(0).AdditionalProperties.TDNumber = "1047";
+
+      string s = exportToXML(model.GetRace(0));
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Jury[@Function='TechnicalDelegate']/Number", s, "1047");
+    }
+
+
+    [TestMethod]
     public void VerifyXML_ResultsWithRuns()
     {
       TestDataGenerator tg = new TestDataGenerator();
@@ -298,17 +315,17 @@ namespace RaceHorologyLibTest
 
       string s = exportToXML(tg.Model.GetRace(0));
 
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_classified/AL_ranked[@Status='QLF']/Bib", s, "1");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_classified/AL_ranked/Timerun1", s, "00:02.00");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_classified/AL_ranked/Timerun2", s, "00:03.00");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_classified/AL_ranked/Totaltime", s, "00:05.00");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_classified/AL_ranked[@Status='QLF']/Bib", s, "1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_classified/AL_ranked/AL_result/Timerun1", s, "02.00");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_classified/AL_ranked/AL_result/Timerun2", s, "03.00");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_classified/AL_ranked/AL_result/Totaltime", s, "05.00");
 
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DNF']/Bib[text()='2']/../Run", s, "2");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='3']/../Run", s, "2");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DNF']/Bib[text()='4']/../Run", s, "1");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DNS']/Bib[text()='5']/../Run", s, "1");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='6']/../Run", s, "1");
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='6']/../Reason", s, "Tor 2");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_notclassified/AL_notranked[@Status='DNF']/Bib[text()='2']/../Run", s, "2");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='3']/../Run", s, "2");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_notclassified/AL_notranked[@Status='DNF']/Bib[text()='4']/../Run", s, "1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_notclassified/AL_notranked[@Status='DNS']/Bib[text()='5']/../Run", s, "1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='6']/../Run", s, "1");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_notclassified/AL_notranked[@Status='DSQ']/Bib[text()='6']/../Reason", s, "Tor 2");
     }
 
 
@@ -337,7 +354,22 @@ namespace RaceHorologyLibTest
 
       string s = exportToXML(model.GetRace(0));
 
-      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_raceinfo/Fvalue", s, "720");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/AL_race/AL_raceinfo/Fvalue", s, "720");
+    }
+
+
+    [TestMethod]
+    public void VerifyXML_RacedateStructure()
+    {
+      var model = createTestDataModel1Race1Run();
+      fillMandatoryFields(model);
+      model.GetRace(0).AdditionalProperties.DateResultList = new DateTime(2026, 4, 26);
+
+      string s = exportToXML(model.GetRace(0));
+
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racedate/Day", s, "26");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racedate/Month", s, "4");
+      XmlAssertion.AssertXPathEvaluatesTo("/Fisresults/Raceheader/Racedate/Year", s, "2026");
     }
 
 
@@ -371,9 +403,9 @@ namespace RaceHorologyLibTest
       raceProps.Description = "Test Race";
       raceProps.Location = "Test Location";
 
+      raceProps.TrainerRepresentative = new AdditionalRaceProperties.Person { Name = "T.Rep", Club = "Club" };
       raceProps.RaceManager = new AdditionalRaceProperties.Person { Name = "Race Manager", Club = "Club" };
       raceProps.RaceReferee = new AdditionalRaceProperties.Person { Name = "Referee, Race", Club = "Club" };
-      raceProps.TrainerRepresentative = new AdditionalRaceProperties.Person { Name = "T.Rep", Club = "Club" };
 
       raceProps.CoarseName = "Kurs 1";
       raceProps.StartHeight = 1000;

--- a/RaceHorologyLibTest/RaceHorologyLibTest.csproj
+++ b/RaceHorologyLibTest/RaceHorologyLibTest.csproj
@@ -180,6 +180,7 @@
     <Compile Include="DSVAlpinDatabaseTests.cs" />
     <Compile Include="DSVCalculationTests.cs" />
     <Compile Include="DSVExportTest.cs" />
+    <Compile Include="FISExportTest.cs" />
     <Compile Include="FISImportTest.cs" />
     <Compile Include="DSVImportTest.cs" />
     <Compile Include="ExportTest.cs" />


### PR DESCRIPTION
Allow export of race data in the FIS format. The output generated includes the XML-file in a zip-folder, which shall be sent to FIS as race report.

Adaptions of the GUI include the necessary fields to make the inputs complieant with the mandatory data of these reports. The added fields do not interfere with DSV or non-association related races.